### PR TITLE
skip_install=true in format, lint, build tox envs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ skip_install = true
 allowlist_externals =
     isort
     black
-deps = 
+deps =
     isort
     black
 commands =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ ignore_missing_imports = True
 # uncomment the following to omit files during running
 #omit =
 [coverage:report]
+skip_empty = true
+skip_covered = true
 exclude_lines =
     pragma: no cover
     def __repr__
@@ -70,10 +72,11 @@ commands =
     pytest --cov=nannyml --cov-branch --cov-report=xml --cov-report=term-missing tests
 
 [testenv:format]
+skip_install = true
 allowlist_externals =
     isort
     black
-deps =
+deps = 
     isort
     black
 commands =
@@ -81,6 +84,7 @@ commands =
     black nannyml tests
 
 [testenv:lint]
+skip_install = true
 allowlist_externals =
     flake8
     mypy
@@ -92,6 +96,7 @@ commands =
     mypy nannyml tests
 
 [testenv:build]
+skip_install = true
 allowlist_externals =
     poetry
     twine


### PR DESCRIPTION
Addressing #111 

In `setup.cfg` added `skip_install=true` in `tox` env config for `format`, `lint` and `build` envs.

Also modified the coverage report config to skip empty and fully covered files, like __init__.py etc (total still shows the overall coverage %)