### PR TITLE
Remove the references heading

### DIFF
--- a/docs/how_it_works/univariate_drift_detection.rst
+++ b/docs/how_it_works/univariate_drift_detection.rst
@@ -205,7 +205,6 @@ We see how the relative frequencies of three categories have changed between ref
 We also see that the resulting L-Infinity distance is the relative frequency change in category c.
 
 
-**References**
 
 .. _`Chi-squared test`: https://en.wikipedia.org/wiki/Chi-squared_test
 .. _`Kolmogorov-Smirnov Test`: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test


### PR DESCRIPTION
Since the references heading doesn't show any links below. Thought it would be better to remove
![image](https://user-images.githubusercontent.com/66986430/203359297-e5887926-3ee2-402c-906d-c04513ee4ded.png)
