### PR TITLE
Fix broken documentation image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Allowing you to have the following benefits:
 
 When the actual outcome of your deployed prediction models is delayed, or even when post-deployment target labels are completely absent, you can use NannyML's [CBPE-algorithm](https://nannyml.readthedocs.io/en/stable/how_it_works/performance_estimation.html#confidence-based-performance-estimation-cbpe) to **estimate model performance** for classification or NannyML's [DLE-algorithm](https://nannyml.readthedocs.io/en/stable/how_it_works/performance_estimation.html#direct-loss-estimation-dle) for regression. These algorithms provide you with any estimated metric you would like, i.e. ROC AUC or RSME. Rather than estimating the performance of future model predictions, CBPE and DLE estimate the expected model performance of the predictions made at inference time.
 
-<p><img src="https://raw.githubusercontent.com/NannyML/nannyml/main/docs/_static/tutorials/performance_calculation/regression/tutorial-performance-calculation-regression-rmse.svg"></p>
+<p><img src="https://raw.githubusercontent.com/NannyML/nannyml/main/docs/_static/tutorials/performance_calculation/regression/tutorial-performance-calculation-regression-RMSE.svg"></p>
 
 NannyML can also **track the realised performance** of your machine learning model once targets are available.
 


### PR DESCRIPTION
Issue [here](https://github.com/NannyML/nannyml/issues/173)

## Summary
- Fix broken documentation image link

## Before
![brokenImageLinkBefore](https://user-images.githubusercontent.com/30363148/208731906-9eaeb01b-d6a8-4090-a57d-cf868f04bee2.jpg)
## After
![brokenImageLinkAfter](https://user-images.githubusercontent.com/30363148/208731912-c51d2bed-ed4e-493f-ae64-677dd6549215.jpg)

## Note:
- Trying my hand at contributing to open source. Feel free to disregard as needed.
