### PR TITLE
Align chunk module doc and exception str to implem params

### DIFF
--- a/nannyml/chunk.py
+++ b/nannyml/chunk.py
@@ -420,7 +420,7 @@ class CountBasedChunker(Chunker):
     --------
     >>> from nannyml.chunk import CountBasedChunker
     >>> df = pd.read_parquet('/path/to/my/data.pq')
-    >>> chunker = CountBasedChunker(chunk_count=100)
+    >>> chunker = CountBasedChunker(chunk_number=100)
     >>> chunks = chunker.split(data=df)
 
     """

--- a/nannyml/chunk.py
+++ b/nannyml/chunk.py
@@ -322,7 +322,7 @@ class SizeBasedChunker(Chunker):
 
     >>> from nannyml.chunk import SizeBasedChunker
     >>> df = pd.read_parquet('/path/to/my/data.pq')
-    >>> chunker = SizeBasedChunker(chunk_size=2000, drop_incomplete = True)
+    >>> chunker = SizeBasedChunker(chunk_size=2000, incomplete='drop')
     >>> chunks = chunker.split(data=df)
 
     """

--- a/nannyml/chunk.py
+++ b/nannyml/chunk.py
@@ -459,15 +459,15 @@ class CountBasedChunker(Chunker):
         # TODO wording
         if not isinstance(chunk_number, int):
             raise InvalidArgumentsException(
-                f"given chunk_count is of type {type(chunk_number)} but should be an int."
+                f"given chunk_number is of type {type(chunk_number)} but should be an int."
                 f"Please provide an integer as a chunk count"
             )
 
         # TODO wording
         if chunk_number <= 0:
             raise InvalidArgumentsException(
-                f"given chunk_count {chunk_number} is less then or equal to zero."
-                f"The chunk count should always be larger then zero"
+                f"given chunk_number {chunk_number} is less then or equal to zero."
+                f"The chunk number should always be larger then zero"
             )
 
         self.chunk_number = chunk_number


### PR DESCRIPTION
Issue [here](https://github.com/NannyML/nannyml/issues/177)

## Summary
Align docstring and exception message to actual params in chunk module

## Testing Approach
Only touched docstring and an exception string so just ran `poetry run tox` to check if there we're any regressions.
![checkForRegression](https://user-images.githubusercontent.com/30363148/211030545-77cc6f8e-aeb7-4e8a-aefd-66fa9a5351d7.jpg)
