### PR TITLE
fix: include missing key on raw files output cli examples

### DIFF
--- a/docs/cli/configuration_file.rst
+++ b/docs/cli/configuration_file.rst
@@ -430,8 +430,9 @@ for the :ref:`dataset-synthetic-binary`. All data is read and written to the loc
         path: data/synthetic_sample_analysis.csv
 
     output:
-      path: out/
-      format: parquet
+      raw_files:
+        path: out/
+        format: parquet
 
     column_mapping:
       features:
@@ -484,12 +485,13 @@ The results are written to another S3 bucket, also using a templated path.
             aws_secret_access_key: 'DATA_SECRET_ACCESS_KEY'
 
     output:
-      path: s3://nml-results/{{year}}/{{month}}/{{day}}
-      format: parquet
-      credentials:  # different credentials
-          client_kwargs:
-            aws_access_key_id: 'RESULTS_ACCESS_KEY_ID'
-            aws_secret_access_key: 'RESULTS_SECRET_ACCESS_KEY'
+      raw_files:
+        path: s3://nml-results/{{year}}/{{month}}/{{day}}
+        format: parquet
+        credentials:  # different credentials
+            client_kwargs:
+              aws_access_key_id: 'RESULTS_ACCESS_KEY_ID'
+              aws_secret_access_key: 'RESULTS_SECRET_ACCESS_KEY'
 
     chunker:
       chunk_size: 5000


### PR DESCRIPTION
Issue here: [Configuration file > Examples](https://nannyml.readthedocs.io/en/stable/cli/configuration_file.html#examples)

## Summary
Missing key `raw_files` inside output config.

Error when following the current example:

```
File "....../nannyml/cli/run.py", line 83, in actually_run_it
    key, kwargs = configured_writers[0]
IndexError: list index out of range
```

## Notes
I was exploring and following the examples, notice this, and I wanted to make a small contribution. Feel free to disregard as needed.