### PR TITLE
Fix missing threshold in plotting legend

### DIFF
--- a/nannyml/plots/blueprints/metrics.py
+++ b/nannyml/plots/blueprints/metrics.py
@@ -332,7 +332,7 @@ def _plot_metric(  # noqa: C901
     # endregion
 
     # region thresholds
-
+    show_threshold_legend = show_in_legend
     if has_reference_results:
         if reference_upper_thresholds is not None:
             figure.add_threshold(
@@ -344,8 +344,9 @@ def _plot_metric(  # noqa: C901
                 with_additional_endpoint=True,
                 subplot_args=dict(row=row, col=col),
                 legendgroup='thresh',
-                showlegend=False,
+                showlegend=show_threshold_legend,
             )
+            show_threshold_legend = False
         if reference_lower_thresholds is not None:
             figure.add_threshold(
                 data=reference_lower_thresholds,
@@ -356,8 +357,9 @@ def _plot_metric(  # noqa: C901
                 with_additional_endpoint=True,
                 subplot_args=dict(row=row, col=col),
                 legendgroup='thresh',
-                showlegend=True,
+                showlegend=show_threshold_legend,
             )
+            show_threshold_legend = False
     if analysis_upper_thresholds is not None:
         figure.add_threshold(
             data=analysis_upper_thresholds,
@@ -368,8 +370,9 @@ def _plot_metric(  # noqa: C901
             with_additional_endpoint=True,
             subplot_args=dict(row=row, col=col),
             legendgroup='thresh',
-            showlegend=False,
+            showlegend=show_threshold_legend,
         )
+        show_threshold_legend = False
 
     if analysis_lower_thresholds is not None:
         figure.add_threshold(
@@ -381,8 +384,9 @@ def _plot_metric(  # noqa: C901
             with_additional_endpoint=True,
             subplot_args=dict(row=row, col=col),
             legendgroup='thresh',
-            showlegend=False,
+            showlegend=show_threshold_legend,
         )
+        show_threshold_legend = False
     # endregion
 
     # region confidence bands


### PR DESCRIPTION
This PR fixes conditional display of the threshold in the plot legend. Previously it would only be displayed if the reference period was present. Now it should always be displayed correctly when present on the plot.

Fixes #218.