### PR TITLE
Fix categorical encoding for DLE

### DIFF
--- a/nannyml/plots/util.py
+++ b/nannyml/plots/util.py
@@ -1,10 +1,7 @@
-#  Author:   Niels Nuyttens  <niels@nannyml.com>
-#  #
-#  License: Apache Software License 2.0
-
-#  Author:   Niels Nuyttens  <niels@nannyml.com>
+#  Author:  Niels Nuyttens  <niels@nannyml.com>
 #
 #  License: Apache Software License 2.0
+
 import copy
 from typing import List, Optional, Tuple, Union
 
@@ -23,8 +20,7 @@ def is_time_series(time_series: Optional[Union[np.ndarray, pd.Series]]) -> TypeG
 
 
 def is_time_based_x_axis(
-    start_dates: Optional[Union[np.ndarray, pd.Series]],
-    end_dates: Optional[Union[np.ndarray, pd.Series]]
+    start_dates: Optional[Union[np.ndarray, pd.Series]], end_dates: Optional[Union[np.ndarray, pd.Series]]
 ) -> bool:
     return is_time_series(start_dates) and is_time_series(end_dates)
 


### PR DESCRIPTION
[LightGBM treats negative values for categorical features as missing values](https://lightgbm.readthedocs.io/en/latest/Advanced-Topics.html#categorical-feature-support).

We currently encode unseen values for categorical features to -1.

This PR adds 1 to the whole feature forcing the encoding of normal values to 1,N instead of 0,N-1 and therefore unseen values end up with 0 which is a valid value for lightgbm categorical features.