### PR TITLE
Fix incorrect legend for threshold of null-series

### DIFF
--- a/nannyml/plots/__init__.py
+++ b/nannyml/plots/__init__.py
@@ -20,6 +20,13 @@ from nannyml.plots.components.hover import (
 from nannyml.plots.components.joy_plot import calculate_chunk_distributions, joy
 from nannyml.plots.components.stacked_bar_plot import calculate_value_counts, stacked_bar
 from nannyml.plots.components.step_plot import alert, metric
-from nannyml.plots.util import add_artificial_endpoint, check_and_convert, ensure_numpy, is_time_based_x_axis, pairwise
+from nannyml.plots.util import (
+    add_artificial_endpoint,
+    check_and_convert,
+    ensure_numpy,
+    has_non_null_data,
+    is_time_based_x_axis,
+    pairwise
+)
 
 CHUNK_KEY_COLUMN_NAME = 'key'

--- a/nannyml/plots/blueprints/metrics.py
+++ b/nannyml/plots/blueprints/metrics.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from nannyml._typing import Key, Result
-from nannyml.plots import Colors, ensure_numpy, is_time_based_x_axis
+from nannyml.plots import Colors, ensure_numpy, has_non_null_data, is_time_based_x_axis
 from nannyml.plots.components import Figure, Hover, render_alert_string, render_period_string, render_x_coordinate
 
 
@@ -334,7 +334,7 @@ def _plot_metric(  # noqa: C901
     # region thresholds
     show_threshold_legend = show_in_legend
     if has_reference_results:
-        if reference_upper_thresholds is not None:
+        if has_non_null_data(reference_upper_thresholds):
             figure.add_threshold(
                 data=reference_upper_thresholds,
                 indices=reference_chunk_indices,
@@ -347,7 +347,7 @@ def _plot_metric(  # noqa: C901
                 showlegend=show_threshold_legend,
             )
             show_threshold_legend = False
-        if reference_lower_thresholds is not None:
+        if has_non_null_data(reference_lower_thresholds):
             figure.add_threshold(
                 data=reference_lower_thresholds,
                 indices=reference_chunk_indices,
@@ -360,7 +360,7 @@ def _plot_metric(  # noqa: C901
                 showlegend=show_threshold_legend,
             )
             show_threshold_legend = False
-    if analysis_upper_thresholds is not None:
+    if has_non_null_data(analysis_upper_thresholds):
         figure.add_threshold(
             data=analysis_upper_thresholds,
             indices=analysis_chunk_indices,
@@ -374,7 +374,7 @@ def _plot_metric(  # noqa: C901
         )
         show_threshold_legend = False
 
-    if analysis_lower_thresholds is not None:
+    if has_non_null_data(analysis_lower_thresholds):
         figure.add_threshold(
             data=analysis_lower_thresholds,
             indices=analysis_chunk_indices,

--- a/nannyml/plots/components/hover.py
+++ b/nannyml/plots/components/hover.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from nannyml.exceptions import InvalidArgumentsException
 from nannyml.plots.colors import Colors
-from nannyml.plots.util import is_time_series
+from nannyml.plots.util import has_non_null_data
 
 
 class Hover:
@@ -98,7 +98,7 @@ def render_x_coordinate(
     end_dates_column: Optional[Union[np.ndarray, pd.Series]] = None,
     date_format: str = '%b-%d-%Y',
 ) -> np.ndarray:
-    if is_time_series(start_dates_column) and is_time_series(end_dates_column):
+    if has_non_null_data(start_dates_column) and has_non_null_data(end_dates_column):
         return np.array(
             [
                 f'From <b>{s.strftime(date_format)}</b> to <b>{e.strftime(date_format)}</b>'

--- a/nannyml/plots/util.py
+++ b/nannyml/plots/util.py
@@ -15,7 +15,7 @@ from nannyml._typing import TypeGuard
 from nannyml.exceptions import InvalidArgumentsException
 
 
-def is_time_series(time_series: Optional[Union[np.ndarray, pd.Series]]) -> TypeGuard[Union[np.ndarray, pd.Series]]:
+def has_non_null_data(time_series: Optional[Union[np.ndarray, pd.Series]]) -> TypeGuard[Union[np.ndarray, pd.Series]]:
     if time_series is None:
         return False
 
@@ -26,7 +26,7 @@ def is_time_based_x_axis(
     start_dates: Optional[Union[np.ndarray, pd.Series]],
     end_dates: Optional[Union[np.ndarray, pd.Series]]
 ) -> bool:
-    return is_time_series(start_dates) and is_time_series(end_dates)
+    return has_non_null_data(start_dates) and has_non_null_data(end_dates)
 
 
 def add_artificial_endpoint(
@@ -40,7 +40,7 @@ def add_artificial_endpoint(
         _data = [np.append(e, e[-1]) for e in data]
     else:
         _data = np.append(_data, _data[-1])
-    if is_time_series(start_dates) and is_time_series(end_dates):
+    if has_non_null_data(start_dates) and has_non_null_data(end_dates):
         _start_dates = copy.deepcopy(start_dates)
         _start_dates = np.append(_start_dates, end_dates[-1])
         return _start_dates, _data


### PR DESCRIPTION
This pull request fixes a bug in threshold plotting when a series of `None` values is provided. Previously this would result in a legend entry without line display.

Before change:
![image](https://user-images.githubusercontent.com/124588413/220639984-9d94681e-142b-4bf0-ba66-f51fbb2bfbf2.png)

After proposed change:
![image](https://user-images.githubusercontent.com/124588413/220639807-bba5601c-0aee-44a3-99de-74f33e2f797f.png)


Fixes #234.