### PR TITLE
fix error message when store load type check fails

### DIFF
--- a/nannyml/io/store/base.py
+++ b/nannyml/io/store/base.py
@@ -77,7 +77,7 @@ class Store(ABC):
             self._logger.info(f'loading object from store "{self}"')
             obj = self._load(**load_args)
             if as_type and not (obj is None or isinstance(obj, as_type)):
-                raise StoreException(f'loaded object is not of type "{type}"')
+                raise StoreException(f'loaded object is not of type "{as_type}"')
             return obj
         except Exception as exc:
             raise StoreException(f'an unexpected exception occurred when loading object: {exc}')

--- a/nannyml/io/store/base.py
+++ b/nannyml/io/store/base.py
@@ -76,7 +76,7 @@ class Store(ABC):
         try:
             self._logger.info(f'loading object from store "{self}"')
             obj = self._load(**load_args)
-            if as_type and not (obj is None or isinstance(obj, as_type)):
+            if as_type and (obj is None or not isinstance(obj, as_type)):
                 raise StoreException(f'loaded object is not of type "{as_type}"')
             return obj
         except Exception as exc:


### PR DESCRIPTION
Fixed error message, 
previously when loading incorrect class:
```Python
store = nannyml.io.store.FilesystemStore(root_path=root_path)
store.load(path=path, as_type=nannyml.CBPE)
```
the error was:
```
raise StoreException(f'loaded object is not of type "{type}"')
nannyml.exceptions.StoreException: loaded object is not of type "<class 'type'>"
```
Now:
```
raise StoreException(f'loaded object is not of type "{as_type}"')
nannyml.exceptions.StoreException: loaded object is not of type "<class 'nannyml.performance_estimation.confidence_based.cbpe.CBPE'>"
```
