### PR TITLE
Make result classes generic to simplify typing

### DIFF
--- a/nannyml/base.py
+++ b/nannyml/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import copy
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Generic, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -23,6 +23,9 @@ from nannyml.exceptions import (
     InvalidArgumentsException,
     InvalidReferenceDataException,
 )
+
+
+MetricLike = TypeVar('MetricLike', bound=Metric)
 
 
 class AbstractResult(ABC):
@@ -122,8 +125,8 @@ class AbstractResult(ABC):
         return self.data.get(key.properties + (property_name,), default=None)
 
 
-class Abstract1DResult(AbstractResult, ABC):
-    def __init__(self, results_data: pd.DataFrame, metrics: Sequence[Metric] = (), *args, **kwargs):
+class Abstract1DResult(AbstractResult, ABC, Generic[MetricLike]):
+    def __init__(self, results_data: pd.DataFrame, metrics: list[MetricLike] = [], *args, **kwargs):
         super().__init__(results_data)
         self.metrics = metrics
 
@@ -163,9 +166,9 @@ class Abstract1DResult(AbstractResult, ABC):
         return res
 
 
-class Abstract2DResult(AbstractResult, ABC):
+class Abstract2DResult(AbstractResult, ABC, Generic[MetricLike]):
     def __init__(
-        self, results_data: pd.DataFrame, metrics: Sequence[Metric] = (), column_names: List[str] = [], *args, **kwargs
+        self, results_data: pd.DataFrame, metrics: list[MetricLike] = [], column_names: List[str] = [], *args, **kwargs
     ):
         super().__init__(results_data)
         self.metrics = metrics

--- a/nannyml/drift/multivariate/data_reconstruction/result.py
+++ b/nannyml/drift/multivariate/data_reconstruction/result.py
@@ -21,7 +21,7 @@ from nannyml.usage_logging import UsageEvent, log_usage
 Metric = namedtuple("Metric", "display_name column_name")
 
 
-class Result(Abstract1DResult, ResultCompareMixin):
+class Result(Abstract1DResult[Metric], ResultCompareMixin):
     """Contains the results of the data reconstruction drift calculation and provides plotting functionality."""
 
     def __init__(

--- a/nannyml/drift/univariate/result.py
+++ b/nannyml/drift/univariate/result.py
@@ -27,7 +27,7 @@ from nannyml.thresholds import StandardDeviationThreshold
 from nannyml.usage_logging import UsageEvent, log_usage
 
 
-class Result(Abstract2DResult, ResultCompareMixin):
+class Result(Abstract2DResult[Method], ResultCompareMixin):
     """Contains the results of the univariate statistical drift calculation and provides plotting functionality."""
 
     def __init__(

--- a/nannyml/performance_calculation/result.py
+++ b/nannyml/performance_calculation/result.py
@@ -19,7 +19,7 @@ from nannyml.plots.blueprints.metrics import plot_metrics
 from nannyml.usage_logging import UsageEvent, log_usage
 
 
-class Result(Abstract1DResult, ResultCompareMixin):
+class Result(Abstract1DResult[Metric], ResultCompareMixin):
     """Contains the results of the realized performance calculation and provides plotting functionality."""
 
     def __init__(

--- a/nannyml/performance_estimation/confidence_based/results.py
+++ b/nannyml/performance_estimation/confidence_based/results.py
@@ -22,7 +22,7 @@ from nannyml.plots.blueprints.metrics import plot_metrics
 from nannyml.usage_logging import UsageEvent, log_usage
 
 
-class Result(Abstract1DResult, ResultCompareMixin):
+class Result(Abstract1DResult[Metric], ResultCompareMixin):
     """Contains results for CBPE estimation and adds plotting functionality."""
 
     def __init__(
@@ -37,9 +37,6 @@ class Result(Abstract1DResult, ResultCompareMixin):
         timestamp_column_name: Optional[str] = None,
     ):
         super().__init__(results_data, metrics)
-
-        # Be more specific about the metric type than the base class
-        self.metrics: List[Metric]
 
         self.y_pred = y_pred
         self.y_pred_proba = y_pred_proba

--- a/nannyml/performance_estimation/direct_loss_estimation/result.py
+++ b/nannyml/performance_estimation/direct_loss_estimation/result.py
@@ -13,7 +13,7 @@ from nannyml.plots.blueprints.metrics import plot_metrics
 from nannyml.usage_logging import UsageEvent, log_usage
 
 
-class Result(Abstract1DResult, ResultCompareMixin):
+class Result(Abstract1DResult[Metric], ResultCompareMixin):
     def __init__(
         self,
         results_data: pd.DataFrame,


### PR DESCRIPTION
**Purpose**
Simplify typing issues when using specialized `Metric` attributes in `Result` classes.

**Why?**
We have a `Protocol` in place for metrics, but our implementations use many specialized attributes. The current approach results in various typing issues that require explicit casting/redefinition of type information to resolve.

Using generics in the base class should avoid most of these problems and make it more intuitive to use.