### PR TITLE
CBPE api reference

### DIFF
--- a/nannyml/performance_estimation/confidence_based/__init__.py
+++ b/nannyml/performance_estimation/confidence_based/__init__.py
@@ -2,7 +2,24 @@
 #
 #  License: Apache Software License 2.0
 
-"""Package containing the Confidence Based Performance Estimator (CBPE)."""
+"""Package containing the Confidence Based Performance Estimator (CBPE).
+
+Assuming properly calibrated probabilities, confusion matrix elements can be estimated and then used to
+calculate any performance metric. Given the assumptions are met, CBPE provides an unbiased estimation of the
+performance of the monitored model based on the monitored model’s outputs only (i.e. without access to targets).
+
+For more information, check out the `tutorial for binary classification`_,
+the `tutorial for multiclass classification`_ or the `deep dive`_.
+
+.. _tutorial for binary classification:
+    https://nannyml.readthedocs.io/en/stable/tutorials/performance_estimation/binary_performance_estimation.html
+
+.. _tutorial for multiclass classification:
+    https://nannyml.readthedocs.io/en/stable/tutorials/performance_estimation/multiclass_performance_estimation.html
+
+.. _deep dive:
+    https://nannyml.readthedocs.io/en/stable/how_it_works/performance_estimation.html#confidence-based-performance-estimation-cbpe
+"""
 
 SUPPORTED_METRIC_VALUES = [
     'roc_auc',

--- a/nannyml/performance_estimation/confidence_based/cbpe.py
+++ b/nannyml/performance_estimation/confidence_based/cbpe.py
@@ -38,8 +38,8 @@ DEFAULT_THRESHOLDS: Dict[str, Threshold] = {
 class CBPE(AbstractEstimator):
     """Performance estimator using the Confidence Based Performance Estimation (CBPE) technique.
 
-    CBPE leverages the confidence score of the model predictions. It is used to estimate the performance of classification
-    models as they return predictions with an associated confidence score.
+    CBPE leverages the confidence score of the model predictions. It is used to estimate the performance of \
+    classification models as they return predictions with an associated confidence score.
     """
 
     def __init__(
@@ -71,7 +71,8 @@ class CBPE(AbstractEstimator):
             Name(s) of the column(s) containing your model output.
 
                 - For binary classification, pass a single string refering to the model output column.
-                - For multiclass classification, pass a dictionary that maps a class string to the column name containing model outputs for that class.
+                - For multiclass classification, pass a dictionary that maps a class string to the column name \
+                containing model outputs for that class.
         y_pred: str
             The name of the column containing your model predictions.
         timestamp_column_name: str, default=None
@@ -137,15 +138,17 @@ class CBPE(AbstractEstimator):
             Determines how the confusion matrix will be normalized. Allowed values are None, 'all', 'true' and
             'predicted'.
 
-                - None - the confusion matrix will not be normalized and the counts for each cell of the matrix will be returned.
+                - None - the confusion matrix will not be normalized and the counts for each cell of the matrix \
+                will be returned.
                 - 'all' - the confusion matrix will be normalized by the total number of observations.
-                - 'true' - the confusion matrix will be normalized by the total number of observations for each true class.
-                - 'predicted' - the confusion matrix will be normalized by the total number of observations for each predicted class.
+                - 'true' - the confusion matrix will be normalized by the total number of observations for each true  \
+                class.
+                - 'predicted' - the confusion matrix will be normalized by the total number of observations for each \
+                predicted class.
         business_value_matrix: Optional[Union[List, np.ndarray]], default=None
             A 2x2 matrix that specifies the value of each cell in the confusion matrix.
-            The format of the business value matrix must be specified as [[value_of_TN, value_of_FP], [value_of_FN, value_of_TP]]
-
-            Required when estimating the 'business_value' metric.
+            The format of the business value matrix must be specified as [[value_of_TN, value_of_FP], \
+            [value_of_FN, value_of_TP]]. Required when estimating the 'business_value' metric.
         normalize_business_value: str, default=None
             Determines how the business value will be normalized. Allowed values are None and
             'per_prediction'.

--- a/nannyml/performance_estimation/confidence_based/cbpe.py
+++ b/nannyml/performance_estimation/confidence_based/cbpe.py
@@ -2,7 +2,6 @@
 #
 #  License: Apache Software License 2.0
 
-"""Implementation of the CBPE estimator."""
 from __future__ import annotations
 
 import copy
@@ -37,7 +36,11 @@ DEFAULT_THRESHOLDS: Dict[str, Threshold] = {
 
 
 class CBPE(AbstractEstimator):
-    """Performance estimator using the Confidence Based Performance Estimation (CBPE) technique."""
+    """Performance estimator using the Confidence Based Performance Estimation (CBPE) technique.
+
+    CBPE leverages the confidence score of the model predictions. It is used to estimate the performance of classification
+    models as they return predictions with an associated confidence score.
+    """
 
     def __init__(
         self,
@@ -152,11 +155,10 @@ class CBPE(AbstractEstimator):
 
         Examples
         --------
+        Using CBPE to estimate the perfomance of a model for a binary classification problem.
+
         >>> import nannyml as nml
-        >>> from IPython.display import display
-        >>> reference_df = nml.load_synthetic_binary_classification_dataset()[0]
-        >>> analysis_df = nml.load_synthetic_binary_classification_dataset()[1]
-        >>> display(reference_df.head(3))
+        >>> reference_df, analysis_df, _ = nml.load_synthetic_binary_classification_dataset()
         >>> estimator = nml.CBPE(
         ...     y_pred_proba='y_pred_proba',
         ...     y_pred='y_pred',
@@ -168,13 +170,30 @@ class CBPE(AbstractEstimator):
         >>> )
         >>> estimator.fit(reference_df)
         >>> results = estimator.estimate(analysis_df)
-        >>> display(results.data)
-        >>> for metric in estimator.metrics:
-        ...     metric_fig = results.plot(kind='performance', metric=metric)
-        ...     metric_fig.show()
-        >>> for metric in estimator.metrics:
-        ...     metric_fig = results.plot(kind='performance', plot_reference=True, metric=metric)
-        ...     metric_fig.show()
+        >>> metric_fig = results.plot()
+        >>> metric_fig.show()
+
+
+        Using CBPE to estimate the perfomance of a model for a multiclass classification problem.
+
+        >>> import nannyml as nml
+        >>> reference_df, analysis_df, _ = nml.load_synthetic_multiclass_classification_dataset()
+        >>> estimator = nml.CBPE(
+        ...     y_pred_proba={
+        ...         'prepaid_card': 'y_pred_proba_prepaid_card',
+        ...         'highstreet_card': 'y_pred_proba_highstreet_card',
+        ...         'upmarket_card': 'y_pred_proba_upmarket_card'},
+        ...     y_pred='y_pred',
+        ...     y_true='y_true',
+        ...     timestamp_column_name='timestamp',
+        ...     problem_type='classification_multiclass',
+        ...     metrics=['roc_auc', 'f1'],
+        ...     chunk_size=6000,
+        >>> )
+        >>> estimator.fit(reference_df)
+        >>> results = estimator.estimate(analysis_df)
+        >>> metric_fig = results.plot()
+        >>> metric_fig.show()
         """
         super().__init__(chunk_size, chunk_number, chunk_period, chunker, timestamp_column_name)
 

--- a/nannyml/performance_estimation/confidence_based/cbpe.py
+++ b/nannyml/performance_estimation/confidence_based/cbpe.py
@@ -38,8 +38,20 @@ DEFAULT_THRESHOLDS: Dict[str, Threshold] = {
 class CBPE(AbstractEstimator):
     """Performance estimator using the Confidence Based Performance Estimation (CBPE) technique.
 
-    CBPE leverages the confidence score of the model predictions. It is used to estimate the performance of \
+    CBPE leverages the confidence score of the model predictions. It is used to estimate the performance of
     classification models as they return predictions with an associated confidence score.
+
+    For more information, check out the `tutorial for binary classification`_,
+    the `tutorial for multiclass classification`_ or the `deep dive`_.
+
+    .. _tutorial for binary classification:
+        https://nannyml.readthedocs.io/en/stable/tutorials/performance_estimation/binary_performance_estimation.html
+
+    .. _tutorial for multiclass classification:
+        https://nannyml.readthedocs.io/en/stable/tutorials/performance_estimation/multiclass_performance_estimation.html
+
+    .. _deep dive:
+        https://nannyml.readthedocs.io/en/stable/how_it_works/performance_estimation.html#confidence-based-performance-estimation-cbpe
     """
 
     def __init__(
@@ -71,8 +83,8 @@ class CBPE(AbstractEstimator):
             Name(s) of the column(s) containing your model output.
 
                 - For binary classification, pass a single string refering to the model output column.
-                - For multiclass classification, pass a dictionary that maps a class string to the column name \
-                containing model outputs for that class.
+                - For multiclass classification, pass a dictionary that maps a class string to the column name
+                  model outputs for that class.
         y_pred: str
             The name of the column containing your model predictions.
         timestamp_column_name: str, default=None
@@ -108,29 +120,23 @@ class CBPE(AbstractEstimator):
         calibrator: Calibrator, default=None
             A specific instance of a Calibrator to be applied to the model predictions.
             If not set NannyML will use the value of the ``calibration`` variable instead.
-        thresholds: dict, default={ \
-            'roc_auc': StandardDeviationThreshold(), \
-            'f1': StandardDeviationThreshold(), \
-            'precision': StandardDeviationThreshold(), \
-            'recall': StandardDeviationThreshold(), \
-            'specificity': StandardDeviationThreshold(), \
-            'accuracy': StandardDeviationThreshold(), \
-            'confusion_matrix': StandardDeviationThreshold(), \
-            'business_value': StandardDeviationThreshold(), \
-        }
+        thresholds: dict
+            The default value is::
+
+                {
+                    'roc_auc': StandardDeviationThreshold(),
+                    'f1': StandardDeviationThreshold(),
+                    'precision': StandardDeviationThreshold(),
+                    'recall': StandardDeviationThreshold(),
+                    'specificity': StandardDeviationThreshold(),
+                    'accuracy': StandardDeviationThreshold(),
+                    'confusion_matrix': StandardDeviationThreshold(),  # only for binary classification
+                    'business_value': StandardDeviationThreshold(),  # only for binary classification
+                }
 
             A dictionary allowing users to set a custom threshold for each method. It links a `Threshold` subclass
             to a method name. This dictionary is optional.
-            If no dictionary is given a default will be applied. The default method thresholds are as follows:
-
-                - `roc_auc`: `StandardDeviationThreshold()`
-                - `f1`: `StandardDeviationThreshold()`
-                - `precision`: `StandardDeviationThreshold()`
-                - `recall`: `StandardDeviationThreshold()`
-                - `specificity`: `StandardDeviationThreshold()`
-                - `accuracy`: `StandardDeviationThreshold()`
-                - `confusion_matrix`: `StandardDeviationThreshold()` - only for binary classification tasks
-                - `business_value`: `StandardDeviationThreshold()` - only for binary classification tasks
+            If no dictionary is given a default will be applied.
         problem_type: Union[str, ProblemType]
             Determines which CBPE implementation to use. Allowed problem type values are 'classification_binary' and
             'classification_multiclass'.
@@ -293,15 +299,6 @@ class CBPE(AbstractEstimator):
         -------
         estimator: PerformanceEstimator
             The fitted estimator.
-
-        Examples
-        --------
-        >>> import nannyml as nml
-        >>> ref_df, ana_df, _ = nml.load_synthetic_binary_classification_dataset()
-        >>> metadata = nml.extract_metadata(ref_df, model_type=nml.ModelType.CLASSIFICATION_BINARY)
-        >>> # create a new estimator and fit it on reference data
-        >>> estimator = nml.CBPE(model_metadata=metadata, chunk_period='W').fit(ref_df)
-
         """
         if self.problem_type == ProblemType.CLASSIFICATION_BINARY:
             return self._fit_binary(reference_data)
@@ -326,15 +323,6 @@ class CBPE(AbstractEstimator):
             object where each row represents a :class:`~nannyml.chunk.Chunk`,
             containing :class:`~nannyml.chunk.Chunk` properties and the estimated metrics
             for that :class:`~nannyml.chunk.Chunk`.
-
-        Examples
-        --------
-        >>> import nannyml as nml
-        >>> ref_df, ana_df, _ = nml.load_synthetic_binary_classification_dataset()
-        >>> metadata = nml.extract_metadata(ref_df, model_type=nml.ModelType.CLASSIFICATION_BINARY)
-        >>> # create a new estimator and fit it on reference data
-        >>> estimator = nml.CBPE(model_metadata=metadata, chunk_period='W').fit(ref_df)
-        >>> estimates = estimator.estimate(data)
         """
         if data.empty:
             raise InvalidArgumentsException('data contains no rows. Please provide a valid data set.')


### PR DESCRIPTION
This PR aims to make the API reference for the CBPE module more clear.

Applied changes:
- Simplify examples by removing unnecessary `IPython.display` calls
- Simplify examples by unpacking datasets instead of accessing them by index
- Create an additional example for showing CBPE for multiclass classification
- Explain the allowed values for the optional and required parameters
- Enhance the description of the CBPE class
