### PR TITLE
Fix incorrect treatment of `az://` URL's in CLI

### DIFF
--- a/nannyml/io/base.py
+++ b/nannyml/io/base.py
@@ -14,7 +14,7 @@ from nannyml._typing import Result
 from nannyml.exceptions import InvalidArgumentsException, ReaderException, WriterException
 
 HTTP_PROTOCOLS = ['http', 'https']
-CLOUD_PROTOCOLS = ['s3', 'gcs', 'gs', 'adl', 'abfs', 'abfss']
+CLOUD_PROTOCOLS = ['s3', 'gcs', 'gs', 'adl', 'abfs', 'abfss', 'az']
 
 
 class Writer(ABC):


### PR DESCRIPTION
Fsspec supports both `az://` and `abfs://` prefixes for azure blob storage. We should also accept both to avoid confusion.