### PR TITLE
Expose metric name for results with components

### DIFF
--- a/nannyml/performance_calculation/result.py
+++ b/nannyml/performance_calculation/result.py
@@ -93,6 +93,7 @@ class Result(PerMetricResult[Metric], ResultCompareMixin):
                 display_names=(
                     f'realized {component[0]}',
                     component[0],
+                    metric.name,
                 ),
             )
             for metric in self.metrics

--- a/nannyml/performance_estimation/confidence_based/results.py
+++ b/nannyml/performance_estimation/confidence_based/results.py
@@ -133,6 +133,7 @@ class Result(PerMetricResult[Metric], ResultCompareMixin):
                 display_names=(
                     f'estimated {component[0]}',
                     component[0],
+                    metric.name,
                 ),
             )
             for metric in self.metrics


### PR DESCRIPTION
This PR is intended to expose both the metric and component name for results which consist of multiple components.

The existing `Key` interface is abused for this purpose to minimize impact. This would be refactored when we review how the calculators/result interface is organized.