### PR TITLE
Fix comparison plot titles

### DIFF
--- a/nannyml/plots/blueprints/comparisons.py
+++ b/nannyml/plots/blueprints/comparisons.py
@@ -614,7 +614,7 @@ def render_display_name(metric_display_name: Union[str, Tuple]):
     if not isinstance(metric_display_name, str):
         if len(metric_display_name) == 1:
             return f'<b>{metric_display_name[0]}</b>'
-        elif len(metric_display_name) == 2:
+        elif len(metric_display_name) >= 2:
             return f'<b>{metric_display_name[1]}</b> ({metric_display_name[0]})'
         else:
             return ', '.join(metric_display_name)
@@ -626,7 +626,7 @@ def render_metric_display_name(metric_display_name: Union[str, Tuple]):
     if not isinstance(metric_display_name, str):
         if len(metric_display_name) == 1:
             return f'<b>{metric_display_name[0]}</b>'
-        elif len(metric_display_name) == 2:
+        elif len(metric_display_name) >= 2:
             return f'<b>{metric_display_name[1]}</b>'
     else:
         return f'<b>{metric_display_name}</b>'


### PR DESCRIPTION
Fixes an issue for comparison plot titles introduced by changes to the display name in #289.

Before fix:
![comparison_plot_title_error](https://github.com/NannyML/nannyml/assets/124588413/9d23c30c-c6c6-401b-8cf5-8644e5691802)

After fix:
![comparison_plot_fixed](https://github.com/NannyML/nannyml/assets/124588413/d4f600c7-4243-4b45-8483-c4aa3d5a3b3d)
