### PR TITLE
Refactor exception types

### DIFF
--- a/nannyml/base.py
+++ b/nannyml/base.py
@@ -18,10 +18,9 @@ from nannyml._typing import Key, Metric, Result, Self
 from nannyml.chunk import Chunker, ChunkerFactory
 from nannyml.exceptions import (
     CalculatorException,
-    CalculatorNotFittedException,
     EstimatorException,
     InvalidArgumentsException,
-    InvalidReferenceDataException,
+    NannyMLException,
 )
 
 MetricLike = TypeVar('MetricLike', bound=Metric)
@@ -88,6 +87,8 @@ class AbstractResult(ABC):
             metrics = [metrics]
         try:
             return self._filter(period, metrics, *args, **kwargs)
+        except NannyMLException:
+            raise
         except Exception as exc:
             raise CalculatorException(f"could not read result data: {exc}")
 
@@ -352,9 +353,7 @@ class AbstractCalculator(ABC):
         try:
             self._logger.debug(f"fitting {str(self)}")
             return self._fit(reference_data, *args, **kwargs)
-        except InvalidArgumentsException:
-            raise
-        except InvalidReferenceDataException:
+        except NannyMLException:
             raise
         except Exception as exc:
             raise CalculatorException(f"failed while fitting {str(self)}.\n{exc}")
@@ -365,9 +364,7 @@ class AbstractCalculator(ABC):
             self._logger.debug(f"calculating {str(self)}")
             data = data.copy()
             return self._calculate(data, *args, **kwargs)
-        except InvalidArgumentsException:
-            raise
-        except CalculatorNotFittedException:
+        except NannyMLException:
             raise
         except Exception as exc:
             raise CalculatorException(f"failed while calculating {str(self)}.\n{exc}")
@@ -433,6 +430,8 @@ class AbstractEstimatorResult(ABC):
             metrics = [metrics]
         try:
             return self._filter(period, metrics, *args, **kwargs)
+        except NannyMLException:
+            raise
         except Exception as exc:
             raise EstimatorException(f"could not read result data: {exc}")
 
@@ -494,9 +493,7 @@ class AbstractEstimator(ABC):
             self._logger.info(f"fitting {str(self)}")
             reference_data = reference_data.copy()
             return self._fit(reference_data, *args, **kwargs)
-        except InvalidArgumentsException:
-            raise
-        except InvalidReferenceDataException:
+        except NannyMLException:
             raise
         except Exception as exc:
             raise CalculatorException(f"failed while fitting {str(self)}.\n{exc}")
@@ -507,9 +504,7 @@ class AbstractEstimator(ABC):
             self._logger.info(f"estimating {str(self)}")
             data = data.copy()
             return self._estimate(data, *args, **kwargs)
-        except InvalidArgumentsException:
-            raise
-        except CalculatorNotFittedException:
+        except NannyMLException:
             raise
         except Exception as exc:
             raise CalculatorException(f"failed while calculating {str(self)}.\n{exc}")

--- a/nannyml/exceptions.py
+++ b/nannyml/exceptions.py
@@ -5,27 +5,31 @@
 """Custom exceptions."""
 
 
-class InvalidArgumentsException(Exception):
+class NannyMLException(Exception):
+    """Base class for all NannyML exceptions."""
+
+
+class InvalidArgumentsException(NannyMLException):
     """An exception indicating that the inputs for a function are invalid."""
 
 
-class ChunkerException(Exception):
+class ChunkerException(NannyMLException):
     """An exception indicating an error occurred somewhere during chunking."""
 
 
-class MissingMetadataException(Exception):
+class MissingMetadataException(NannyMLException):
     """An exception indicating metadata columns are missing from the dataframe being processed."""
 
 
-class InvalidReferenceDataException(Exception):
+class InvalidReferenceDataException(NannyMLException):
     """An exception indicating the reference data provided are invalid."""
 
 
-class CalculatorException(Exception):
+class CalculatorException(NannyMLException):
     """An exception indicating an error occurred during calculation."""
 
 
-class EstimatorException(Exception):
+class EstimatorException(NannyMLException):
     """An exception indicating an error occurred during estimation."""
 
 
@@ -33,33 +37,33 @@ class CalculatorNotFittedException(CalculatorException):
     """An exception indicating a calculator was not fitted before using it in calculations."""
 
 
-class NotFittedException(Exception):
+class NotFittedException(NannyMLException):
     """An exception indicating an object was not fitted before using it."""
 
 
-class WriterException(Exception):
+class WriterException(NannyMLException):
     """An exception indicating something went wrong whilst trying to write out results."""
 
 
-class ReaderException(Exception):
+class ReaderException(NannyMLException):
     """An exception indicating something went wrong whilst trying to read out data."""
 
 
-class IOException(Exception):
+class IOException(NannyMLException):
     """An exception indicating something went wrong during IO."""
 
 
-class StoreException(Exception):
+class StoreException(NannyMLException):
     """An exception indicating something went wrong whilst using a store."""
 
 
-class SerializeException(Exception):
+class SerializeException(NannyMLException):
     """An exception occurring when serialization some object went wrong."""
 
 
-class DeserializeException(Exception):
+class DeserializeException(NannyMLException):
     """An exception occurring when deserialization some object went wrong."""
 
 
-class ThresholdException(Exception):
+class ThresholdException(NannyMLException):
     """An exception occurring during threshold creation or calculation."""


### PR DESCRIPTION
This PR has two purposes:

* Introduction of a new `NannyMLException` type to serve as base class for all NannyML exceptions. It's intended to easily allow capturing exceptions generated by NannyML, while ignoring others.
* Fixing a bug introduced in commit [fe92481b389ae2b0ed32d2804cadadc573807567](https://github.com/NannyML/nannyml/commit/fe92481b389ae2b0ed32d2804cadadc573807567) which caused `InvalidArgumentsException` to be incorrectly translated to `CalculatorException`.