### PR TITLE
Fix paragraph padding in docs

### DIFF
--- a/docs/_static/js/mendablesearch.js
+++ b/docs/_static/js/mendablesearch.js
@@ -66,7 +66,7 @@ document.addEventListener("DOMContentLoaded", () => {
             "https://unpkg.com/react-dom@17/umd/react-dom.production.min.js",
             () => {
                 loadScript(
-                    "https://unpkg.com/@mendable/search@0.0.102/dist/umd/mendable.min.js",
+                    "https://unpkg.com/@mendable/search@0.0.114/dist/umd/mendable.min.js",
                     initializeMendable
                 );
             }


### PR DESCRIPTION
This PR updates mendable search plugin in the docs to version 0.0.114 to resolve styling issues. The previous version of the mendable plugin introduced styling overrides that interfered with our read the docs theme.