### PR TITLE
Improve handling `object` dtype for perf calculation

### DIFF
--- a/nannyml/performance_calculation/metrics/base.py
+++ b/nannyml/performance_calculation/metrics/base.py
@@ -272,4 +272,8 @@ def _common_data_cleaning(y_true: pd.Series, y_pred: Union[pd.Series, pd.DataFra
     y_pred = y_pred[~y_true.isna()]
     y_true.dropna(inplace=True)
 
+    # NaN values have been dropped. Try to infer types again
+    y_pred = y_pred.infer_objects()
+    y_true = y_true.infer_objects()
+
     return y_true, y_pred

--- a/nannyml/performance_estimation/confidence_based/metrics.py
+++ b/nannyml/performance_estimation/confidence_based/metrics.py
@@ -251,6 +251,11 @@ class Metric(abc.ABC):
         y_pred = y_pred[mask]
         y_true = y_true[mask] if y_true is not None else None
 
+        # NaN values have been dropped. Try to infer types again
+        y_pred_proba = y_pred_proba.infer_objects()
+        y_pred = y_pred.infer_objects()
+        y_true = y_true.infer_objects() if y_true is not None else None
+
         return y_pred_proba, y_pred, y_true
 
     def get_chunk_record(self, chunk_data: pd.DataFrame) -> Dict:

--- a/nannyml/performance_estimation/confidence_based/metrics.py
+++ b/nannyml/performance_estimation/confidence_based/metrics.py
@@ -238,16 +238,18 @@ class Metric(abc.ABC):
         y_pred_proba = data[y_pred_proba_column_name]
         y_pred = data[self.y_pred]
 
-        y_pred_proba.dropna(inplace=True)
-
+        # Create mask to filter out NaN values
         if clean_targets:
             y_true = data[self.y_true]
-            y_true = y_true[~y_pred_proba.isna()]
-            y_pred_proba = y_pred_proba[~y_true.isna()]
-            y_pred = y_pred[~y_true.isna()]
-            y_true.dropna(inplace=True)
+            mask = ~(y_pred.isna() | y_pred_proba.isna() | y_true.isna())
         else:
             y_true = None
+            mask = ~(y_pred.isna() | y_pred_proba.isna())
+
+        # Drop missing values (NaN/None)
+        y_pred_proba = y_pred_proba[mask]
+        y_pred = y_pred[mask]
+        y_true = y_true[mask] if y_true is not None else None
 
         return y_pred_proba, y_pred, y_true
 

--- a/nannyml/performance_estimation/confidence_based/metrics.py
+++ b/nannyml/performance_estimation/confidence_based/metrics.py
@@ -237,7 +237,7 @@ class Metric(abc.ABC):
 
         y_pred_proba = data[y_pred_proba_column_name]
         y_pred = data[self.y_pred]
-        y_true = data[self.y_true]
+        y_true = data[self.y_true] if clean_targets else None
 
         # Create mask to filter out NaN values
         mask = ~(y_pred.isna() | y_pred_proba.isna())
@@ -247,12 +247,14 @@ class Metric(abc.ABC):
         # Drop missing values (NaN/None)
         y_pred_proba = y_pred_proba[mask]
         y_pred = y_pred[mask]
-        y_true = y_true[mask] if clean_targets else None
+        if clean_targets:
+            y_true = y_true[mask]
 
         # NaN values have been dropped. Try to infer types again
         y_pred_proba = y_pred_proba.infer_objects()
         y_pred = y_pred.infer_objects()
-        y_true = y_true.infer_objects() if clean_targets else None
+        if clean_targets:
+            y_true = y_true.infer_objects()
 
         return y_pred_proba, y_pred, y_true
 

--- a/nannyml/performance_estimation/confidence_based/metrics.py
+++ b/nannyml/performance_estimation/confidence_based/metrics.py
@@ -237,24 +237,22 @@ class Metric(abc.ABC):
 
         y_pred_proba = data[y_pred_proba_column_name]
         y_pred = data[self.y_pred]
+        y_true = data[self.y_true]
 
         # Create mask to filter out NaN values
+        mask = ~(y_pred.isna() | y_pred_proba.isna())
         if clean_targets:
-            y_true = data[self.y_true]
-            mask = ~(y_pred.isna() | y_pred_proba.isna() | y_true.isna())
-        else:
-            y_true = None
-            mask = ~(y_pred.isna() | y_pred_proba.isna())
+            mask = mask | ~(y_true.isna())
 
         # Drop missing values (NaN/None)
         y_pred_proba = y_pred_proba[mask]
         y_pred = y_pred[mask]
-        y_true = y_true[mask] if y_true is not None else None
+        y_true = y_true[mask] if clean_targets else None
 
         # NaN values have been dropped. Try to infer types again
         y_pred_proba = y_pred_proba.infer_objects()
         y_pred = y_pred.infer_objects()
-        y_true = y_true.infer_objects() if y_true is not None else None
+        y_true = y_true.infer_objects() if clean_targets else None
 
         return y_pred_proba, y_pred, y_true
 

--- a/tests/performance_calculation/test_performance_calculator.py
+++ b/tests/performance_calculation/test_performance_calculator.py
@@ -180,6 +180,27 @@ def test_calculator_calculate_should_include_target_completeness_rate(data):  # 
     assert sut.loc[1, ('chunk', 'targets_missing_rate')] == 0.9
 
 
+def test_calculator_calculate_should_support_partial_bool_targets(data, performance_calculator):
+    """Test that the calculator supports partial bool targets.
+
+    Pandas converts bool columns to object dtype when they contain NaN values. This previously resulted in problems
+    when calculating the performance metrics. This test ensures that the calculator supports partial bool targets.
+    """
+    ref_data = data[0]
+    analysis_data = data[1].merge(data[2], on='identifier')
+
+    # Convert target column to bool dtype
+    analysis_data = analysis_data.astype({'work_home_actual': 'bool'})
+
+    # Drop 10% of the target values in the first chunk
+    analysis_data.loc[0:499, 'work_home_actual'] = np.NAN
+
+    performance_calculator.fit(reference_data=ref_data)
+    performance_calculator.calculate(analysis_data)
+
+    # No further checks needed, if the above code runs without errors, the test passes.
+
+
 @pytest.mark.parametrize(
     'custom_thresholds',
     [


### PR DESCRIPTION
This PR improves handling of columns with `object` dtype for performance calculation.

## Problem

A binary classification dataset with targets stored as true/false will normally be read using `bool` dtype. However, if some targets are missing pandas will instead use the `object` dtype to handle mixed values. This causes the `roc_auc` metric to fail with:
> ValueError: unknown format is not supported

## Proposed changes

During performance calculation, NannyML strips the missing values but the column dtype remains `object`. This PR changes this behaviour to re-infer the dtype using pandas for the `y_true`, `y_pred` and `y_pred_proba` columns once the missing values have been removed.

In the problem case described above, this will result in the `y_true` column receiving a `bool` dtype and successful calculation of the `roc_auc` metric.

## Other changes

The data cleaning performed in performance estimation didn't behave correctly if there are missing values in the `y_pred_proba` or `y_pred` columns. This has also been fixed.