### PR TITLE
Adding PSI for continious data

### DIFF
--- a/nannyml/drift/univariate/calculator.py
+++ b/nannyml/drift/univariate/calculator.py
@@ -12,6 +12,7 @@ Supported drift detection methods are:
 - L-infinity distance (categorical)
 - Jensen-Shannon distance
 - Hellinger distance
+- Population Stability Index (continuous)
 
 For more information, check out the `tutorial`_ or the `deep dive`_.
 
@@ -50,6 +51,7 @@ DEFAULT_THRESHOLDS: Dict[str, Threshold] = {
     'wasserstein': StandardDeviationThreshold(std_lower_multiplier=None),
     'hellinger': ConstantThreshold(lower=None, upper=0.1),
     'l_infinity': ConstantThreshold(lower=None, upper=0.1),
+    'psi': ConstantThreshold(lower=None, upper=0.25),
 }
 
 
@@ -97,6 +99,7 @@ class UnivariateDriftCalculator(AbstractCalculator):
                 - `kolmogorov_smirnov`
                 - `hellinger`
                 - `wasserstein`
+                - `psi`
         chunk_size: int
             Splits the data into chunks containing `chunks_size` observations.
             Only one of `chunk_size`, `chunk_number` or `chunk_period` should be given.
@@ -118,6 +121,7 @@ class UnivariateDriftCalculator(AbstractCalculator):
                     'wasserstein': StandardDeviationThreshold(std_lower_multiplier=None),
                     'hellinger': ConstantThreshold(upper=0.1),
                     'l_infinity': ConstantThreshold(upper=0.1)
+                    'psi': ConstantThreshold(upper=0.25)
                 }
 
             A dictionary allowing users to set a custom threshold for each method. It links a `Threshold` subclass
@@ -130,6 +134,7 @@ class UnivariateDriftCalculator(AbstractCalculator):
                 - `wasserstein`: `StandardDeviationThreshold(std_lower_multiplier=None)`
                 - `hellinger`: `ConstantThreshold(upper=0.1)`
                 - `l_infinity`: `ConstantThreshold(upper=0.1)`
+                - `psi`: `ConstantThreshold(upper=0.25)`
 
             The `chi2` method does not support custom thresholds for now. Additional research is required to determine
             how to transition from its current p-value based implementation.

--- a/tests/drift/test_drift.py
+++ b/tests/drift/test_drift.py
@@ -322,6 +322,7 @@ def test_univariate_drift_calculator_without_custom_thresholds():
             'hellinger': ConstantThreshold(lower=1, upper=2),
             'jensen_shannon': ConstantThreshold(lower=1, upper=2),
             'l_infinity': ConstantThreshold(lower=1, upper=2),
+            'psi': ConstantThreshold(lower=1, upper=2),
         },
     ],
 )


### PR DESCRIPTION
added Population Stability Index (PSI) for continuous data. 

I used 0.25 as the alerting threshold citing this -> https://www.risk.net/journal-of-risk-model-validation/7725371/statistical-properties-of-the-population-stability-index#:~:text=In%20practice%2C%20the%20following%20%E2%80%9Crule,or%20type%20II%20error%20rates.

Used to Freedman-Diaconis Rule determine bin size 

also updated the comments in drift/methods to say drift metric, instead of performance metrics 

I recommend looking at the calculations and math closely to see whether it makes sense. 

I'll add it for categorical next 