### PR TITLE
Fix handling `NaN` values when fitting JS univariate drift

### DIFF
--- a/nannyml/base.py
+++ b/nannyml/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import copy
 import logging
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Generic, Iterable, List, Optional, Tuple, TypeVar, Union, overload
 
 import numpy as np
 import pandas as pd
@@ -533,17 +533,38 @@ def _column_is_categorical(column: pd.Series) -> bool:
     return column.dtype in ['object', 'string', 'category', 'bool']
 
 
-def _clean_data(*data: Union[pd.Series, pd.DataFrame]) -> Tuple[pd.DataFrame, ...]:
-    """Remove rows with NaN values from the given data."""
-    mask = np.ones(len(data[0]), dtype=bool)
-    for df in data:
-        if isinstance(df, pd.DataFrame):
-            mask &= ~df.isna().all(axis=1)
-        else:
-            mask &= ~df.isna()
+@overload
+def _remove_nans(data: pd.Series, columns: None) -> pd.Series:
+    ...
+
+@overload
+def _remove_nans(data: pd.DataFrame, columns: Optional[Iterable[Union[str, Iterable[str]]]]) -> pd.DataFrame:
+    ...
+
+
+def _remove_nans(
+    data: Union[pd.Series, pd.DataFrame], columns: Optional[Iterable[Union[str, Iterable[str]]]] = None
+) -> Tuple[pd.DataFrame, ...]:
+    """Remove rows with NaN values in the specified columns.
+
+    If no columns are given, drop rows with NaN values in any column. If columns are given, drop rows with NaN values
+    in the specified columns. If a set of columns is given, drop rows with NaN values in all of the columns in the set.
+    """
+    # If no columns are given, drop rows with NaN values in any columns
+    if columns is None:
+        mask = ~data.isna()
+        if isinstance(mask, pd.DataFrame):
+            mask = mask.all(axis=1)
+    else:
+        mask = np.ones(len(data), dtype=bool)
+        for column_selector in columns:
+            nans = data[column_selector].isna()
+            if isinstance(nans, pd.DataFrame):
+                nans = nans.all(axis=1)
+            mask &= ~nans
 
     # NaN values have been dropped. Try to infer types again
-    return tuple(df[mask].reset_index(drop=True).infer_objects() for df in data)
+    return data[mask].reset_index(drop=True).infer_objects()
 
 
 def _column_is_continuous(column: pd.Series) -> bool:

--- a/nannyml/base.py
+++ b/nannyml/base.py
@@ -534,7 +534,7 @@ def _column_is_categorical(column: pd.Series) -> bool:
 
 
 @overload
-def _remove_nans(data: pd.Series, columns: None) -> pd.Series:
+def _remove_nans(data: pd.Series) -> pd.Series:
     ...
 
 @overload

--- a/nannyml/drift/univariate/methods.py
+++ b/nannyml/drift/univariate/methods.py
@@ -29,7 +29,7 @@ from scipy.spatial.distance import jensenshannon
 from scipy.stats import chi2_contingency, ks_2samp, wasserstein_distance
 
 from nannyml._typing import Self
-from nannyml.base import _clean_data, _column_is_categorical
+from nannyml.base import _remove_nans, _column_is_categorical
 from nannyml.chunk import Chunker
 from nannyml.exceptions import InvalidArgumentsException, NotFittedException
 from nannyml.thresholds import Threshold, calculate_threshold_values
@@ -278,7 +278,7 @@ class JensenShannonDistance(Method):
         self._reference_proba_in_bins: np.ndarray
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None):
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         if _column_is_categorical(reference_data):
             treat_as_type = 'cat'
         else:
@@ -306,7 +306,7 @@ class JensenShannonDistance(Method):
 
     def _calculate(self, data: pd.Series):
         reference_proba_in_bins = copy(self._reference_proba_in_bins)
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         if self._treat_as_type == 'cont':
@@ -375,7 +375,7 @@ class KolmogorovSmirnovStatistic(Method):
             self.n_bins = kwargs['computation_params'].get('n_bins', 10_000)
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         if (self.calculation_method == 'auto' and len(reference_data) < 10_000) or self.calculation_method == 'exact':
             self._reference_data = reference_data
         else:
@@ -390,7 +390,7 @@ class KolmogorovSmirnovStatistic(Method):
         return self
 
     def _calculate(self, data: pd.Series):
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         if not self._fitted:
@@ -444,13 +444,13 @@ class Chi2Statistic(Method):
         self._fitted = False
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         self._reference_data_vcs = reference_data.value_counts().loc[lambda v: v != 0]
         self._fitted = True
         return self
 
     def _calculate(self, data: pd.Series):
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         if not self._fitted:
@@ -506,7 +506,7 @@ class LInfinityDistance(Method):
         self._reference_proba: Optional[dict] = None
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         ref_labels = reference_data.unique()
         self._reference_proba = {label: (reference_data == label).sum() / len(reference_data) for label in ref_labels}
 
@@ -517,7 +517,7 @@ class LInfinityDistance(Method):
             raise NotFittedException(
                 "tried to call 'calculate' on an unfitted method " f"{self.display_name}. Please run 'fit' first"
             )
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         data_labels = data.unique()
@@ -575,7 +575,7 @@ class WassersteinDistance(Method):
             self.n_bins = kwargs['computation_params'].get('n_bins', 10_000)
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         if (self.calculation_method == 'auto' and len(reference_data) < 10_000) or self.calculation_method == 'exact':
             self._reference_data = reference_data
         else:
@@ -593,7 +593,7 @@ class WassersteinDistance(Method):
             raise NotFittedException(
                 "tried to call 'calculate' on an unfitted method " f"{self.display_name}. Please run 'fit' first"
             )
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         if (
@@ -669,7 +669,7 @@ class HellingerDistance(Method):
         self._reference_proba_in_bins: np.ndarray
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data, = _clean_data(reference_data)
+        reference_data = _remove_nans(reference_data)
         if _column_is_categorical(reference_data):
             treat_as_type = 'cat'
         else:
@@ -696,7 +696,7 @@ class HellingerDistance(Method):
         return self
 
     def _calculate(self, data: pd.Series):
-        data, = _clean_data(data)
+        data = _remove_nans(data)
         if data.empty:
             return np.nan
         reference_proba_in_bins = copy(self._reference_proba_in_bins)

--- a/nannyml/drift/univariate/methods.py
+++ b/nannyml/drift/univariate/methods.py
@@ -278,6 +278,7 @@ class JensenShannonDistance(Method):
         self._reference_proba_in_bins: np.ndarray
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None):
+        reference_data, = _clean_data(reference_data)
         if _column_is_categorical(reference_data):
             treat_as_type = 'cat'
         else:

--- a/nannyml/drift/univariate/methods.py
+++ b/nannyml/drift/univariate/methods.py
@@ -29,7 +29,7 @@ from scipy.spatial.distance import jensenshannon
 from scipy.stats import chi2_contingency, ks_2samp, wasserstein_distance
 
 from nannyml._typing import Self
-from nannyml.base import _column_is_categorical, _remove_missing_data
+from nannyml.base import _clean_data, _column_is_categorical
 from nannyml.chunk import Chunker
 from nannyml.exceptions import InvalidArgumentsException, NotFittedException
 from nannyml.thresholds import Threshold, calculate_threshold_values
@@ -305,7 +305,7 @@ class JensenShannonDistance(Method):
 
     def _calculate(self, data: pd.Series):
         reference_proba_in_bins = copy(self._reference_proba_in_bins)
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         if self._treat_as_type == 'cont':
@@ -374,7 +374,7 @@ class KolmogorovSmirnovStatistic(Method):
             self.n_bins = kwargs['computation_params'].get('n_bins', 10_000)
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data = _remove_missing_data(reference_data)
+        reference_data, = _clean_data(reference_data)
         if (self.calculation_method == 'auto' and len(reference_data) < 10_000) or self.calculation_method == 'exact':
             self._reference_data = reference_data
         else:
@@ -389,7 +389,7 @@ class KolmogorovSmirnovStatistic(Method):
         return self
 
     def _calculate(self, data: pd.Series):
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         if not self._fitted:
@@ -443,13 +443,13 @@ class Chi2Statistic(Method):
         self._fitted = False
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data = _remove_missing_data(reference_data)
+        reference_data, = _clean_data(reference_data)
         self._reference_data_vcs = reference_data.value_counts().loc[lambda v: v != 0]
         self._fitted = True
         return self
 
     def _calculate(self, data: pd.Series):
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         if not self._fitted:
@@ -505,7 +505,7 @@ class LInfinityDistance(Method):
         self._reference_proba: Optional[dict] = None
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data = _remove_missing_data(reference_data)
+        reference_data, = _clean_data(reference_data)
         ref_labels = reference_data.unique()
         self._reference_proba = {label: (reference_data == label).sum() / len(reference_data) for label in ref_labels}
 
@@ -516,7 +516,7 @@ class LInfinityDistance(Method):
             raise NotFittedException(
                 "tried to call 'calculate' on an unfitted method " f"{self.display_name}. Please run 'fit' first"
             )
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         data_labels = data.unique()
@@ -574,7 +574,7 @@ class WassersteinDistance(Method):
             self.n_bins = kwargs['computation_params'].get('n_bins', 10_000)
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data = _remove_missing_data(reference_data)
+        reference_data, = _clean_data(reference_data)
         if (self.calculation_method == 'auto' and len(reference_data) < 10_000) or self.calculation_method == 'exact':
             self._reference_data = reference_data
         else:
@@ -592,7 +592,7 @@ class WassersteinDistance(Method):
             raise NotFittedException(
                 "tried to call 'calculate' on an unfitted method " f"{self.display_name}. Please run 'fit' first"
             )
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         if (
@@ -668,7 +668,7 @@ class HellingerDistance(Method):
         self._reference_proba_in_bins: np.ndarray
 
     def _fit(self, reference_data: pd.Series, timestamps: Optional[pd.Series] = None) -> Self:
-        reference_data = _remove_missing_data(reference_data)
+        reference_data, = _clean_data(reference_data)
         if _column_is_categorical(reference_data):
             treat_as_type = 'cat'
         else:
@@ -695,7 +695,7 @@ class HellingerDistance(Method):
         return self
 
     def _calculate(self, data: pd.Series):
-        data = _remove_missing_data(data)
+        data, = _clean_data(data)
         if data.empty:
             return np.nan
         reference_proba_in_bins = copy(self._reference_proba_in_bins)

--- a/nannyml/performance_calculation/metrics/base.py
+++ b/nannyml/performance_calculation/metrics/base.py
@@ -255,25 +255,3 @@ class MetricFactory:
             return wrapped_class
 
         return inner_wrapper
-
-
-def _common_data_cleaning(y_true: pd.Series, y_pred: Union[pd.Series, pd.DataFrame]):
-    y_true, y_pred = (
-        y_true.reset_index(drop=True),
-        y_pred.reset_index(drop=True),
-    )
-
-    if isinstance(y_pred, pd.DataFrame):
-        y_true = y_true[~y_pred.isna().all(axis=1)]
-    else:
-        y_true = y_true[~y_pred.isna()]
-    y_pred.dropna(inplace=True)
-
-    y_pred = y_pred[~y_true.isna()]
-    y_true.dropna(inplace=True)
-
-    # NaN values have been dropped. Try to infer types again
-    y_pred = y_pred.infer_objects()
-    y_true = y_true.infer_objects()
-
-    return y_true, y_pred

--- a/nannyml/performance_calculation/metrics/binary_classification.py
+++ b/nannyml/performance_calculation/metrics/binary_classification.py
@@ -9,10 +9,10 @@ import pandas as pd
 from sklearn.metrics import confusion_matrix, f1_score, precision_score, recall_score, roc_auc_score
 
 from nannyml._typing import ProblemType
-from nannyml.base import _list_missing
+from nannyml.base import _clean_data, _list_missing
 from nannyml.chunk import Chunk, Chunker
 from nannyml.exceptions import InvalidArgumentsException
-from nannyml.performance_calculation.metrics.base import Metric, MetricFactory, _common_data_cleaning
+from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
 from nannyml.sampling_error.binary_classification import (
     accuracy_sampling_error,
     accuracy_sampling_error_components,
@@ -97,7 +97,7 @@ class BinaryClassificationAUROC(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred_proba]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if y_true.nunique() <= 1:
             warnings.warn("Calculated ROC-AUC score contains NaN values.")
@@ -166,7 +166,7 @@ class BinaryClassificationF1(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated F1-score contains NaN values.")
@@ -234,7 +234,7 @@ class BinaryClassificationPrecision(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Precision score contains NaN values.")
@@ -302,7 +302,7 @@ class BinaryClassificationRecall(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Recall score contains NaN values.")
@@ -375,7 +375,7 @@ class BinaryClassificationSpecificity(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Specificity score contains NaN values.")
@@ -449,7 +449,7 @@ class BinaryClassificationAccuracy(Metric):
                 f"could not calculate metric '{self.display_name}': " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Accuracy score contains NaN values.")
@@ -556,7 +556,7 @@ class BinaryClassificationBusinessValue(Metric):
                 f"could not calculate metric '{self.name}': " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true is None:
             warnings.warn("Calculated Business Value contains NaN values.")
             return np.NaN
@@ -752,7 +752,7 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric true_positive. prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_positives contain NaN values.")
             return np.nan
@@ -781,7 +781,7 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric true_negative. prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_negatives contain NaN values.")
             return np.nan
@@ -810,7 +810,7 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric false_positive. prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_positives contain NaN values.")
             return np.nan
@@ -839,7 +839,7 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric false_negative. prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_negatives contain NaN values.")
             return np.nan

--- a/nannyml/performance_calculation/metrics/binary_classification.py
+++ b/nannyml/performance_calculation/metrics/binary_classification.py
@@ -367,11 +367,6 @@ class BinaryClassificationSpecificity(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                f"could not calculate metric {self.display_name}: " "prediction column contains no data"
-            )
-
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Specificity score contains NaN values.")
             return np.nan
@@ -439,11 +434,6 @@ class BinaryClassificationAccuracy(Metric):
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                f"could not calculate metric '{self.display_name}': " "prediction column contains no data"
-            )
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Accuracy score contains NaN values.")
@@ -546,14 +536,6 @@ class BinaryClassificationBusinessValue(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                f"could not calculate metric '{self.name}': " "prediction column contains no data"
-            )
-
-        if y_true is None:
-            warnings.warn("Calculated Business Value contains NaN values.")
-            return np.NaN
         if y_true.shape[0] == 0:
             warnings.warn("Calculated Business Value contains NaN values.")
             return np.NaN
@@ -742,11 +724,6 @@ class BinaryClassificationConfusionMatrix(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                "could not calculate metric true_positive. prediction column contains no data"
-            )
-
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_positives contain NaN values.")
             return np.nan
@@ -770,11 +747,6 @@ class BinaryClassificationConfusionMatrix(Metric):
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                "could not calculate metric true_negative. prediction column contains no data"
-            )
 
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_negatives contain NaN values.")
@@ -800,10 +772,6 @@ class BinaryClassificationConfusionMatrix(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                "could not calculate metric false_positive. prediction column contains no data"
-            )
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_positives contain NaN values.")
             return np.nan
@@ -827,11 +795,6 @@ class BinaryClassificationConfusionMatrix(Metric):
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        if y_pred.isna().all():
-            raise InvalidArgumentsException(
-                "could not calculate metric false_negative. prediction column contains no data"
-            )
 
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_negatives contain NaN values.")

--- a/nannyml/performance_calculation/metrics/binary_classification.py
+++ b/nannyml/performance_calculation/metrics/binary_classification.py
@@ -9,7 +9,7 @@ import pandas as pd
 from sklearn.metrics import confusion_matrix, f1_score, precision_score, recall_score, roc_auc_score
 
 from nannyml._typing import ProblemType
-from nannyml.base import _clean_data, _list_missing
+from nannyml.base import _remove_nans, _list_missing
 from nannyml.chunk import Chunk, Chunker
 from nannyml.exceptions import InvalidArgumentsException
 from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
@@ -93,11 +93,10 @@ class BinaryClassificationAUROC(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred_proba], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred_proba]
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if y_true.nunique() <= 1:
             warnings.warn("Calculated ROC-AUC score contains NaN values.")
@@ -162,11 +161,10 @@ class BinaryClassificationF1(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated F1-score contains NaN values.")
@@ -230,11 +228,10 @@ class BinaryClassificationPrecision(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Precision score contains NaN values.")
@@ -298,11 +295,10 @@ class BinaryClassificationRecall(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Recall score contains NaN values.")
@@ -366,6 +362,7 @@ class BinaryClassificationSpecificity(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -374,8 +371,6 @@ class BinaryClassificationSpecificity(Metric):
             raise InvalidArgumentsException(
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Specificity score contains NaN values.")
@@ -440,6 +435,7 @@ class BinaryClassificationAccuracy(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -448,8 +444,6 @@ class BinaryClassificationAccuracy(Metric):
             raise InvalidArgumentsException(
                 f"could not calculate metric '{self.display_name}': " "prediction column contains no data"
             )
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
 
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Accuracy score contains NaN values.")
@@ -547,6 +541,7 @@ class BinaryClassificationBusinessValue(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -556,7 +551,6 @@ class BinaryClassificationBusinessValue(Metric):
                 f"could not calculate metric '{self.name}': " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true is None:
             warnings.warn("Calculated Business Value contains NaN values.")
             return np.NaN
@@ -743,6 +737,7 @@ class BinaryClassificationConfusionMatrix(Metric):
 
     def _calculate_true_positives(self, data: pd.DataFrame) -> float:
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -752,7 +747,6 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric true_positive. prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_positives contain NaN values.")
             return np.nan
@@ -772,6 +766,7 @@ class BinaryClassificationConfusionMatrix(Metric):
 
     def _calculate_true_negatives(self, data: pd.DataFrame) -> float:
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -781,7 +776,6 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric true_negative. prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated true_negatives contain NaN values.")
             return np.nan
@@ -801,6 +795,7 @@ class BinaryClassificationConfusionMatrix(Metric):
 
     def _calculate_false_positives(self, data: pd.DataFrame) -> float:
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -809,8 +804,6 @@ class BinaryClassificationConfusionMatrix(Metric):
             raise InvalidArgumentsException(
                 "could not calculate metric false_positive. prediction column contains no data"
             )
-
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_positives contain NaN values.")
             return np.nan
@@ -830,6 +823,7 @@ class BinaryClassificationConfusionMatrix(Metric):
 
     def _calculate_false_negatives(self, data: pd.DataFrame) -> float:
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -839,7 +833,6 @@ class BinaryClassificationConfusionMatrix(Metric):
                 "could not calculate metric false_negative. prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             warnings.warn("Calculated false_negatives contain NaN values.")
             return np.nan

--- a/nannyml/performance_calculation/metrics/multiclass_classification.py
+++ b/nannyml/performance_calculation/metrics/multiclass_classification.py
@@ -24,10 +24,10 @@ from sklearn.metrics import (
 from sklearn.preprocessing import LabelBinarizer, label_binarize
 
 from nannyml._typing import ProblemType, class_labels, model_output_column_names
-from nannyml.base import _list_missing
+from nannyml.base import _clean_data, _list_missing
 from nannyml.chunk import Chunker
 from nannyml.exceptions import InvalidArgumentsException
-from nannyml.performance_calculation.metrics.base import Metric, MetricFactory, _common_data_cleaning
+from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
 from nannyml.sampling_error.multiclass_classification import (
     accuracy_sampling_error,
     accuracy_sampling_error_components,
@@ -130,7 +130,7 @@ class MulticlassClassificationAUROC(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.nunique() <= 1:
             warnings.warn("Calculated ROC-AUC score contains NaN values.")
             return np.nan
@@ -218,7 +218,7 @@ class MulticlassClassificationF1(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated F1-score contains NaN values.")
             return np.nan
@@ -306,7 +306,7 @@ class MulticlassClassificationPrecision(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Precision score contains NaN values.")
             return np.nan
@@ -394,7 +394,7 @@ class MulticlassClassificationRecall(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Recall score contains NaN values.")
             return np.nan
@@ -482,7 +482,7 @@ class MulticlassClassificationSpecificity(Metric):
                 f"could not calculate metric {self.display_name}: prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Specificity score contains NaN values.")
             return np.nan
@@ -566,7 +566,7 @@ class MulticlassClassificationAccuracy(Metric):
                 f"could not calculate metric '{self.display_name}': " "prediction column contains no data"
             )
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Accuracy score contains NaN values.")
             return np.nan

--- a/nannyml/performance_calculation/metrics/multiclass_classification.py
+++ b/nannyml/performance_calculation/metrics/multiclass_classification.py
@@ -24,7 +24,7 @@ from sklearn.metrics import (
 from sklearn.preprocessing import LabelBinarizer, label_binarize
 
 from nannyml._typing import ProblemType, class_labels, model_output_column_names
-from nannyml.base import _clean_data, _list_missing
+from nannyml.base import _remove_nans, _list_missing
 from nannyml.chunk import Chunker
 from nannyml.exceptions import InvalidArgumentsException
 from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
@@ -116,6 +116,7 @@ class MulticlassClassificationAUROC(Metric):
             )
 
         _list_missing([self.y_true] + model_output_column_names(self.y_pred_proba), data)
+        data = _remove_nans(data, (self.y_true, self.y_pred_proba.values()))
 
         labels, class_probability_columns = [], []
         for label in sorted(list(self.y_pred_proba.keys())):
@@ -123,19 +124,18 @@ class MulticlassClassificationAUROC(Metric):
             class_probability_columns.append(self.y_pred_proba[label])
 
         y_true = data[self.y_true]
-        y_pred = data[class_probability_columns]
+        y_pred_proba = data[class_probability_columns]
 
-        if y_pred.isna().all().any():
+        if y_pred_proba.isna().all().any():
             raise InvalidArgumentsException(
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.nunique() <= 1:
             warnings.warn("Calculated ROC-AUC score contains NaN values.")
             return np.nan
         else:
-            return roc_auc_score(y_true, y_pred, multi_class='ovr', average='macro', labels=labels)
+            return roc_auc_score(y_true, y_pred_proba, multi_class='ovr', average='macro', labels=labels)
 
     def _sampling_error(self, data: pd.DataFrame) -> float:
         return auroc_sampling_error(self._sampling_error_components, data)
@@ -208,6 +208,7 @@ class MulticlassClassificationF1(Metric):
             )
 
         _list_missing([self.y_true, self.y_pred], data)
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         labels = sorted(list(self.y_pred_proba.keys()))
         y_true = data[self.y_true]
@@ -218,7 +219,6 @@ class MulticlassClassificationF1(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated F1-score contains NaN values.")
             return np.nan
@@ -296,6 +296,7 @@ class MulticlassClassificationPrecision(Metric):
             )
 
         _list_missing([self.y_true, self.y_pred], data)
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         labels = sorted(list(self.y_pred_proba.keys()))
         y_true = data[self.y_true]
@@ -306,7 +307,6 @@ class MulticlassClassificationPrecision(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Precision score contains NaN values.")
             return np.nan
@@ -384,6 +384,7 @@ class MulticlassClassificationRecall(Metric):
             )
 
         _list_missing([self.y_true, self.y_pred], data)
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         labels = sorted(list(self.y_pred_proba.keys()))
         y_true = data[self.y_true]
@@ -394,7 +395,6 @@ class MulticlassClassificationRecall(Metric):
                 f"could not calculate metric {self.display_name}: " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Recall score contains NaN values.")
             return np.nan
@@ -472,6 +472,7 @@ class MulticlassClassificationSpecificity(Metric):
             )
 
         _list_missing([self.y_true, self.y_pred], data)
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         labels = sorted(list(self.y_pred_proba.keys()))
         y_true = data[self.y_true]
@@ -482,7 +483,6 @@ class MulticlassClassificationSpecificity(Metric):
                 f"could not calculate metric {self.display_name}: prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Specificity score contains NaN values.")
             return np.nan
@@ -557,6 +557,7 @@ class MulticlassClassificationAccuracy(Metric):
 
     def _calculate(self, data: pd.DataFrame):
         _list_missing([self.y_true, self.y_pred], data)
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
@@ -566,7 +567,6 @@ class MulticlassClassificationAccuracy(Metric):
                 f"could not calculate metric '{self.display_name}': " "prediction column contains no data"
             )
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if (y_true.nunique() <= 1) or (y_pred.nunique() <= 1):
             warnings.warn("Calculated Accuracy score contains NaN values.")
             return np.nan

--- a/nannyml/performance_calculation/metrics/regression.py
+++ b/nannyml/performance_calculation/metrics/regression.py
@@ -13,8 +13,8 @@ from sklearn.metrics import (
 )
 
 from nannyml._typing import ProblemType
-from nannyml.base import _list_missing, _raise_exception_for_negative_values
-from nannyml.performance_calculation.metrics.base import Metric, MetricFactory, _common_data_cleaning
+from nannyml.base import _clean_data, _list_missing, _raise_exception_for_negative_values
+from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
 from nannyml.sampling_error.regression import (
     mae_sampling_error,
     mae_sampling_error_components,
@@ -80,7 +80,7 @@ class MAE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -138,7 +138,7 @@ class MAPE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -196,7 +196,7 @@ class MSE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -254,7 +254,7 @@ class MSLE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -317,7 +317,7 @@ class RMSE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -375,7 +375,7 @@ class RMSLE(Metric):
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _common_data_cleaning(y_true, y_pred)
+        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 

--- a/nannyml/performance_calculation/metrics/regression.py
+++ b/nannyml/performance_calculation/metrics/regression.py
@@ -13,7 +13,7 @@ from sklearn.metrics import (
 )
 
 from nannyml._typing import ProblemType
-from nannyml.base import _clean_data, _list_missing, _raise_exception_for_negative_values
+from nannyml.base import _remove_nans, _list_missing, _raise_exception_for_negative_values
 from nannyml.performance_calculation.metrics.base import Metric, MetricFactory
 from nannyml.sampling_error.regression import (
     mae_sampling_error,
@@ -76,11 +76,11 @@ class MAE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -134,11 +134,11 @@ class MAPE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -192,11 +192,11 @@ class MSE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -250,11 +250,11 @@ class MSLE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -313,11 +313,11 @@ class RMSE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 
@@ -371,11 +371,11 @@ class RMSLE(Metric):
     def _calculate(self, data: pd.DataFrame):
         """Redefine to handle NaNs and edge cases."""
         _list_missing([self.y_true, self.y_pred], list(data.columns))
+        data = _remove_nans(data, (self.y_true, self.y_pred))
 
         y_true = data[self.y_true]
         y_pred = data[self.y_pred]
 
-        y_true, y_pred = _clean_data(y_true, y_pred)
         if y_true.empty or y_pred.empty:
             return np.nan
 


### PR DESCRIPTION
Primary purpose for this PR is to fix fitting Jensen Shannon method when reference data contains `NaN` values, described in #339.

### Changes
- Remove `NaN`'s from reference data when fitting JS.
- Refactored to use a common data cleaning method, previously there were different variations in use across calculators.
- Improved error reporting when fitting univariate calculator methods to specify method and column name that failed.
- Removed `InvalidArgumentException` about `NaN` arguments from performance calculation so `NaN` will be returned instead with a warning message. This should be in line with behaviour for other calculators.

### Note
I've not added special handling when reference data contains only `NaN` values. This will still result in the exception mentioned in #339 (with mention of the violating method and column name). This likely applies for most univariate drift methods, if not all of them.

This seems like a different case than analysis data containing only `NaN` values that we should still evaluate.