### PR TITLE
Fix running CLI with join column for target data

### DIFF
--- a/nannyml/runner.py
+++ b/nannyml/runner.py
@@ -298,6 +298,6 @@ def _add_targets_to_analysis_data(
     analysis_data: pd.DataFrame, target_data: pd.DataFrame, join_column: Optional[str]
 ) -> pd.DataFrame:
     if join_column is not None:
-        return analysis_data.merge(target_data, on=target_data.join_column)
+        return analysis_data.merge(target_data, on=join_column)
     else:
         return analysis_data.join(target_data)


### PR DESCRIPTION
This PR fixes running the CLI with a join column specified for the target dataset.

For example:
``` yaml
input:
  reference_data:
    path: https://github.com/NannyML/nannyml/raw/main/nannyml/datasets/data/regression_synthetic_reference.csv
  analysis_data:
    path: https://github.com/NannyML/nannyml/raw/main/nannyml/datasets/data/regression_synthetic_analysis.csv
  target_data:
    path: https://github.com/NannyML/nannyml/raw/main/nannyml/datasets/data/regression_synthetic_analysis_targets.csv
    join_column: id
```