### PR TITLE
Fix duplicate X-values in KDE distribution

### DIFF
--- a/nannyml/distribution/continuous/calculator.py
+++ b/nannyml/distribution/continuous/calculator.py
@@ -83,6 +83,12 @@ def _get_kde(array, cut=3, clip=(-np.inf, np.inf)):
     try:  # pragma: no cover
         kde = sm.nonparametric.KDEUnivariate(array)
         kde.fit(cut=cut, clip=clip)
+
+        # Calculation may return duplicate support values in edge cases. These results are not sensible. Treating it as
+        # an error case and returning None
+        if len(np.unique(kde.support)) < len(kde.support):
+            return None
+
         return kde
     except Exception:
         return None

--- a/nannyml/plots/components/joy_plot.py
+++ b/nannyml/plots/components/joy_plot.py
@@ -21,6 +21,12 @@ def _get_kde(array, cut=3, clip=(-np.inf, np.inf)):
     try:  # pragma: no cover
         kde = sm.nonparametric.KDEUnivariate(array)
         kde.fit(cut=cut, clip=clip)
+
+        # Calculation may return duplicate support values in edge cases. These results are not sensible. Treating it as
+        # an error case and returning None
+        if len(np.unique(kde.support)) < len(kde.support):
+            return None
+
         return kde
     except Exception:
         return None


### PR DESCRIPTION
This PR addresses an issue for KDE distribution calculation returning duplicate X-values. This is an edge case of the `statsmodel.nonparametric.KDEUnivariate` function.

Reproduction example:
``` python
from statsmodels import api as sm
from matplotlib import pyplot as plt

data = [-0.100865, -0.100865, -0.100865, -0.100865, -0.100865]
kde = sm.nonparametric.KDEUnivariate(data)
kde.fit()

print("nr duplicate X-values:", len(kde.support) - len(np.unique(kde.support)))
plt.plot(kde.support, kde.density)
```

Output:
nr duplicate X-values: 505
![image](https://github.com/NannyML/nannyml/assets/124588413/3cc95e6b-a05d-42f6-a29a-2061877b4781)

Normally input data containing a single value would result in an exception, but in this case it does not due to some form of precision error. 

Running the above example with different input data yields:
* `data = np.array([-0.100865, -0.100865, -0.100865, -0.100865, -0.100865], dtype='float16')` => error
* `data = np.array([-0.100865, -0.100865, -0.100865, -0.100865, -0.100865], dtype='float32')` => error
* `data = np.array([-0.100865, -0.100865, -0.100865, -0.100865, -0.100865], dtype='float64')` => same output as example above