### PR TITLE
Make prediction column optional for performance estimation / calculation.

### DIFF
--- a/docs/tutorials/data_requirements.rst
+++ b/docs/tutorials/data_requirements.rst
@@ -170,7 +170,7 @@ The :term:`predicted label<Predicted labels>`, retrieved by interpreting (thresh
 In the sample data this is the **y_pred** column.
 
 Required for running :ref:`performance estimation<performance-estimation>` or :ref:`performance calculation<performance-calculation>` on binary classification, multiclass, and regression models.
-
+On binary classification models, it is not required for calculating the **AUROC** and **average precision** metrics.
 
 NannyML Functionality Requirements
 ----------------------------------
@@ -190,7 +190,8 @@ You can see those requirements in the table below:
 | y_pred_proba | Required (reference and analysis)   |                                     |                                     |                                   |                                   |                                   | Required (reference and analysis) |
 +--------------+-------------------------------------+-------------------------------------+-------------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+
 | y_pred       | | Required (reference and analysis) | Required (reference and analysis)   | | Required (reference and analysis) |                                   |                                   |                                   | Required (reference and analysis) |
-|              | | Not needed for ROC_AUC metric     |                                     | | Not needed for ROC_AUC metric     |                                   |                                   |                                   |                                   |
+|              | | Not needed for ROC_AUC or         |                                     | | Not needed for ROC_AUC or         |                                   |                                   |                                   |                                   |
+|              | | average precision metrics         |                                     | | average precision metrics         |                                   |                                   |                                   |                                   |
 +--------------+-------------------------------------+-------------------------------------+-------------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+
 | y_true       | Required (reference only)           |  Required (reference only)          | Required (reference and analysis)   |                                   |                                   | Required (reference and analysis) |                                   |
 +--------------+-------------------------------------+-------------------------------------+-------------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+-----------------------------------+

--- a/nannyml/performance_calculation/result.py
+++ b/nannyml/performance_calculation/result.py
@@ -30,7 +30,7 @@ class Result(PerMetricResult[Metric], ResultCompareMixin):
         self,
         results_data: pd.DataFrame,
         problem_type: ProblemType,
-        y_pred: str,
+        y_pred: Optional[str],
         y_pred_proba: Optional[Union[str, Dict[str, str]]],
         y_true: str,
         metrics: List[Metric],

--- a/nannyml/performance_estimation/confidence_based/cbpe.py
+++ b/nannyml/performance_estimation/confidence_based/cbpe.py
@@ -346,7 +346,10 @@ class CBPE(AbstractEstimator):
             raise InvalidArgumentsException('data contains no rows. Please provide a valid data set.')
 
         if self.problem_type == ProblemType.CLASSIFICATION_BINARY:
-            _list_missing([self.y_pred, self.y_pred_proba], data)
+            required_cols = [self.y_pred_proba]
+            if self.y_pred is not None:
+                required_cols.append(self.y_pred)
+            _list_missing(required_cols, list(data.columns))
 
             # We need uncalibrated data to calculate the realized performance on.
             # https://github.com/NannyML/nannyml/issues/98
@@ -419,7 +422,10 @@ class CBPE(AbstractEstimator):
         if reference_data.empty:
             raise InvalidArgumentsException('data contains no rows. Please provide a valid data set.')
 
-        _list_missing([self.y_true, self.y_pred_proba, self.y_pred], list(reference_data.columns))
+        required_cols = [self.y_true, self.y_pred_proba]
+        if self.y_pred is not None:
+            required_cols.append(self.y_pred)
+        _list_missing(required_cols, list(reference_data.columns))
 
         # We need uncalibrated data to calculate the realized performance on.
         # We need realized performance in threshold calculations.

--- a/nannyml/performance_estimation/confidence_based/results.py
+++ b/nannyml/performance_estimation/confidence_based/results.py
@@ -30,7 +30,7 @@ class Result(PerMetricResult[Metric], ResultCompareMixin):
         self,
         results_data: pd.DataFrame,
         metrics: List[Metric],
-        y_pred: str,
+        y_pred: Optional[str],
         y_pred_proba: ModelOutputsType,
         y_true: str,
         chunker: Chunker,

--- a/nannyml/sampling_error/summary_stats.py
+++ b/nannyml/sampling_error/summary_stats.py
@@ -2,12 +2,12 @@
 #
 #  License: Apache Software License 2.0
 
+import warnings
 from logging import getLogger
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
-import warnings
 from scipy.stats import gaussian_kde, moment
 
 logger = getLogger(__name__)

--- a/tests/performance_calculation/test_performance_calculator.py
+++ b/tests/performance_calculation/test_performance_calculator.py
@@ -462,3 +462,17 @@ def test_binary_classification_result_plots_raise_no_exceptions(calc_args, plot_
         _ = sut.plot(**plot_args)
     except Exception as exc:
         pytest.fail(f"an unexpected exception occurred: {exc}")
+
+
+def test_binary_classification_calculate_without_prediction_column():
+    reference, analysis, analysis_targets = load_synthetic_binary_classification_dataset()
+    calc = PerformanceCalculator(
+        y_true='work_home_actual',
+        y_pred_proba='y_pred_proba',
+        problem_type=ProblemType.CLASSIFICATION_BINARY,
+        metrics=['roc_auc', 'average_precision'],
+        timestamp_column_name='timestamp',
+        chunk_period='M'
+    ).fit(reference)
+    res = calc.calculate(analysis.merge(analysis_targets, on='id'))
+    

--- a/tests/performance_calculation/test_performance_calculator.py
+++ b/tests/performance_calculation/test_performance_calculator.py
@@ -466,13 +466,15 @@ def test_binary_classification_result_plots_raise_no_exceptions(calc_args, plot_
 
 def test_binary_classification_calculate_without_prediction_column():
     reference, analysis, analysis_targets = load_synthetic_binary_classification_dataset()
-    calc = PerformanceCalculator(
-        y_true='work_home_actual',
-        y_pred_proba='y_pred_proba',
-        problem_type=ProblemType.CLASSIFICATION_BINARY,
-        metrics=['roc_auc', 'average_precision'],
-        timestamp_column_name='timestamp',
-        chunk_period='M'
-    ).fit(reference)
-    res = calc.calculate(analysis.merge(analysis_targets, on='id'))
-    
+    try:
+        calc = PerformanceCalculator(
+            y_true='work_home_actual',
+            y_pred_proba='y_pred_proba',
+            problem_type=ProblemType.CLASSIFICATION_BINARY,
+            metrics=['roc_auc', 'average_precision'],
+            timestamp_column_name='timestamp',
+            chunk_period='M',
+        ).fit(reference)
+        _ = calc.calculate(analysis.merge(analysis_targets, on='id'))
+    except Exception as exc:
+        pytest.fail(f"an unexpected exception occurred: {exc}")

--- a/tests/performance_estimation/CBPE/test_cbpe.py
+++ b/tests/performance_estimation/CBPE/test_cbpe.py
@@ -702,3 +702,19 @@ def test_cbpe_with_default_thresholds():
     sut = est.thresholds
 
     assert sut == DEFAULT_THRESHOLDS
+
+
+def test_cbpe_without_predictions():
+    ref_df, ana_df, _ = load_synthetic_binary_classification_dataset()
+    cbpe = CBPE(
+        y_pred_proba='y_pred_proba',
+        y_true='work_home_actual',
+        problem_type='classification_binary',
+        metrics=[
+            'roc_auc',
+            'average_precision',
+        ],
+        timestamp_column_name='timestamp',
+        chunk_period='M',
+    ).fit(ref_df)
+    result = cbpe.estimate(ana_df)

--- a/tests/performance_estimation/CBPE/test_cbpe.py
+++ b/tests/performance_estimation/CBPE/test_cbpe.py
@@ -706,15 +706,18 @@ def test_cbpe_with_default_thresholds():
 
 def test_cbpe_without_predictions():
     ref_df, ana_df, _ = load_synthetic_binary_classification_dataset()
-    cbpe = CBPE(
-        y_pred_proba='y_pred_proba',
-        y_true='work_home_actual',
-        problem_type='classification_binary',
-        metrics=[
-            'roc_auc',
-            'average_precision',
-        ],
-        timestamp_column_name='timestamp',
-        chunk_period='M',
-    ).fit(ref_df)
-    result = cbpe.estimate(ana_df)
+    try:
+        cbpe = CBPE(
+            y_pred_proba='y_pred_proba',
+            y_true='work_home_actual',
+            problem_type='classification_binary',
+            metrics=[
+                'roc_auc',
+                'average_precision',
+            ],
+            timestamp_column_name='timestamp',
+            chunk_period='M',
+        ).fit(ref_df)
+        _ = cbpe.estimate(ana_df)
+    except Exception as exc:
+        pytest.fail(f'unexpected exception: {exc}')

--- a/tests/performance_estimation/CBPE/test_cbpe.py
+++ b/tests/performance_estimation/CBPE/test_cbpe.py
@@ -64,6 +64,56 @@ def test_cbpe_create_with_single_or_list_of_metrics(metrics, expected):
     assert [metric.name for metric in sut.metrics] == expected
 
 
+@pytest.mark.parametrize(
+    'problem',
+    [
+        "classification_multiclass",
+        "regression",
+    ],
+)
+def test_cbpe_create_raises_exception_when_y_pred_not_given_and_problem_type_not_binary_classification(problem):
+    with pytest.raises(InvalidArgumentsException, match=f"'y_pred' can not be 'None' for problem type {problem}"):
+        _ = CBPE(
+            timestamp_column_name='timestamp',
+            y_pred_proba='y_pred_proba',
+            y_true='y_true',
+            metrics=['roc_auc', 'f1'],
+            problem_type=problem,
+        )
+
+
+@pytest.mark.parametrize(
+    'metric, expected',
+    [
+        (['roc_auc', 'f1'], "['f1']"),
+        (['roc_auc', 'f1', 'average_precision', 'precision'], "['f1', 'precision']"),
+    ],
+)
+def test_cbpe_create_without_y_pred_raises_exception_when_metrics_require_it(metric, expected):
+    with pytest.raises(InvalidArgumentsException, match=expected):
+        _ = CBPE(
+            timestamp_column_name='timestamp',
+            y_pred_proba='y_pred_proba',
+            y_true='y_true',
+            metrics=metric,
+            problem_type='classification_binary',
+        )
+
+
+@pytest.mark.parametrize('metric', ['roc_auc', 'average_precision'])
+def test_cbpe_create_without_y_pred_works_when_metrics_dont_require_it(metric):
+    try:
+        _ = CBPE(
+            timestamp_column_name='timestamp',
+            y_pred_proba='y_pred_proba',
+            y_true='y_true',
+            metrics=metric,
+            problem_type='classification_binary',
+        )
+    except Exception as exc:
+        pytest.fail(f'unexpected exception: {exc}')
+
+
 def test_cbpe_will_calibrate_scores_when_needed(binary_classification_data):  # noqa: D103
     ref_df = binary_classification_data[0]
 


### PR DESCRIPTION
This PR makes the `y_pred` column name optional for realised and estimated performance calculators in binary classification problem types.

When no `y_pred` column is given, only `AUROC` and `average precision` are allowed as metric values.