### PR TITLE
Fix filtering for components in CBPE result

### DIFF
--- a/nannyml/performance_estimation/confidence_based/results.py
+++ b/nannyml/performance_estimation/confidence_based/results.py
@@ -104,6 +104,7 @@ class Result(PerMetricResult[Metric], ResultCompareMixin):
         metric_column_names = [name for metric in filtered_metrics for name in metric.column_names]
 
         res = super()._filter(period, metric_column_names, *args, **kwargs)
+        res.metrics = filtered_metrics
 
         return res
 


### PR DESCRIPTION
This PR fixes filtering for components in CBPE results.

The bug was introduced in #288 where the metric assignment on the `nannyml.performance_estimation.confidence_based.results.Result` class was removed in favour of the base class. Performance calculation was not impacted.