### PR TITLE
Chore: the big dependency bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.0] - 2024-09-06
+## [0.12.1] - 2024-09-06
 
 ### Fixed
 


### PR DESCRIPTION
This is the one: the big dependency bump!

As Python 3.8 is end-of-life, this release drops the support for it. This allows us to bump a lot of our core dependencies:

```toml
numpy = "^2.0"

scipy = "^1.13"

pandas = "^2.2"

scikit-learn = "^1.6"

pyarrow = "^18.1"
```
This should be a lot less restrictive for people with up-to-date installations.
Working with these versions means we now support Python 3.12 as well!