### PR TITLE
Fix categorical distribution legends

### DIFF
--- a/nannyml/categorical_plot_example.py
+++ b/nannyml/categorical_plot_example.py
@@ -1,0 +1,37 @@
+# https://community.plotly.com/t/plotly-subplots-with-individual-legends/1754/25
+
+import nannyml as nml
+
+
+def main():
+    reference_df, analysis_df, _ = nml.load_synthetic_car_loan_dataset()
+
+    column_names = [
+        "car_value",
+        "salary_range",
+        "debt_to_income_ratio",
+        "loan_length",
+        "repaid_loan_on_prev_car",
+        "size_of_downpayment",
+        "driver_tenure",
+        "y_pred_proba",
+        "y_pred",
+    ]
+
+    calc = nml.UnivariateDriftCalculator(
+        column_names=column_names,
+        treat_as_categorical=["y_pred"],
+        timestamp_column_name="timestamp",
+        categorical_methods=["jensen_shannon"],
+    )
+
+    calc.fit(reference_df)
+
+    result = calc.calculate(analysis_df)
+
+    figure = result.filter(
+        column_names=result.categorical_column_names,
+        methods=["jensen_shannon"],
+    ).plot(kind="distribution")
+
+    figure.show()

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -300,7 +300,10 @@ def _plot_stacked_bar(
             annotation='Reference',
             showlegend=True,
             subplot_args=subplot_args,
-        )
+        )      
+
+        assert reference_chunk_indices is not None
+        analysis_chunk_indices = analysis_chunk_indices + (max(reference_chunk_indices) + 1)
 
     analysis_value_counts = calculate_value_counts(
         data=analysis_data,

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -279,7 +279,8 @@ def _plot_stacked_bar(
     timestamps = analysis_data_timestamps
     if has_reference_results:
         data = pd.concat([reference_data, analysis_data]).reset_index(drop=True)
-        timestamps = pd.concat([reference_data_timestamps, analysis_data_timestamps]).reset_index(drop=True)
+        if reference_data_timestamps is not None:
+            timestamps = pd.concat([reference_data_timestamps, analysis_data_timestamps]).reset_index(drop=True)
         analysis_chunk_indices = analysis_chunk_indices + (max(reference_chunk_indices) + 1)
         # TODO: split proportionally.
         if isinstance(chunker, DefaultChunker):

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -305,8 +305,6 @@ def _plot_stacked_bar(
             chunk_end_dates=reference_chunk_end_dates,
             annotation='Reference',
             showlegend=True,
-            legendgrouptitle_text=f'<b>{column_name}</b>',
-            legendgroup=column_name,
             subplot_args=subplot_args,
         )
 
@@ -322,7 +320,6 @@ def _plot_stacked_bar(
         chunk_end_dates=analysis_chunk_end_dates,
         annotation='Analysis',
         showlegend=False,
-        legendgroup=column_name,
         subplot_args=subplot_args,
     )
 
@@ -334,9 +331,14 @@ def _plot_stacked_bar(
         chunk_indices=analysis_chunk_indices,
         chunk_start_dates=analysis_chunk_start_dates,
         chunk_end_dates=analysis_chunk_end_dates,
-        showlegend=True,
-        legendgroup=column_name,
+        showlegend=False,
         subplot_args=subplot_args,
     )
+
+    # https://community.plotly.com/t/plotly-subplots-with-individual-legends/1754/25
+    legend_name = f"legend{row}"
+    yaxis = list(figure.select_yaxes())[row - 1]
+    figure.update_layout({legend_name: dict(y=yaxis.domain[1], yanchor="top")})
+    figure.update_traces(row=row, legend=legend_name)
 
     return figure

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -84,6 +84,7 @@ def plot_distributions(
                 figure=figure,
                 row=row,
                 col=col,
+                idx=idx,
                 chunker=chunker,
                 column_name=column_name,
                 metric_display_name=method,
@@ -251,6 +252,7 @@ def _plot_stacked_bar(
     analysis_chunk_end_dates: Optional[Union[np.ndarray, pd.Series]] = None,
     row: Optional[int] = None,
     col: Optional[int] = None,
+    idx: Optional[int] = None,
     hover: Optional[Hover] = None,
 ) -> Figure:
     is_subplot = row is not None and col is not None
@@ -335,10 +337,12 @@ def _plot_stacked_bar(
         subplot_args=subplot_args,
     )
 
-    # https://community.plotly.com/t/plotly-subplots-with-individual-legends/1754/25
-    legend_name = f"legend{row}"
-    yaxis = list(figure.select_yaxes())[row - 1]
-    figure.update_layout({legend_name: dict(y=yaxis.domain[1], yanchor="top")})
-    figure.update_traces(row=row, legend=legend_name)
+    if is_subplot:
+        # https://community.plotly.com/t/plotly-subplots-with-individual-legends/1754/25
+        legend_name = f"legend{idx + 1}"
+        xaxis = list(figure.select_xaxes())[idx]
+        yaxis = list(figure.select_yaxes())[idx]
+        figure.update_layout({legend_name: dict(x=xaxis.domain[1], y=yaxis.domain[1], yanchor="top")})
+        figure.update_traces(row=row, col=col, legend=legend_name)
 
     return figure

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -300,7 +300,7 @@ def _plot_stacked_bar(
             annotation='Reference',
             showlegend=True,
             subplot_args=subplot_args,
-        )      
+        )
 
         assert reference_chunk_indices is not None
         analysis_chunk_indices = analysis_chunk_indices + (max(reference_chunk_indices) + 1)

--- a/nannyml/plots/blueprints/distributions.py
+++ b/nannyml/plots/blueprints/distributions.py
@@ -7,14 +7,14 @@ from typing import Any, Dict, Optional, Union
 import numpy as np
 import pandas as pd
 
-from nannyml.chunk import Chunker, CountBasedChunker, DefaultChunker
+from nannyml.chunk import Chunker
 from nannyml.exceptions import InvalidArgumentsException
 from nannyml.plots import Colors
 from nannyml.plots.components import Figure, Hover
 from nannyml.plots.components.joy_plot import alert as joy_alert
 from nannyml.plots.components.joy_plot import calculate_chunk_distributions, joy
 from nannyml.plots.components.stacked_bar_plot import alert as stacked_bar_alert
-from nannyml.plots.components.stacked_bar_plot import calculate_value_counts, stacked_bar
+from nannyml.plots.components.stacked_bar_plot import calculate_value_counts, categorize_data, stacked_bar
 from nannyml.plots.util import is_time_based_x_axis
 
 
@@ -275,28 +275,19 @@ def _plot_stacked_bar(
         dict(mirror=False, showline=False), overwrite=True, title=figure.layout.yaxis.title, row=row, col=col
     )
 
-    data = analysis_data
-    timestamps = analysis_data_timestamps
+    data_to_categorize = analysis_data
     if has_reference_results:
-        data = pd.concat([reference_data, analysis_data]).reset_index(drop=True)
-        if reference_data_timestamps is not None:
-            timestamps = pd.concat([reference_data_timestamps, analysis_data_timestamps]).reset_index(drop=True)
-        analysis_chunk_indices = analysis_chunk_indices + (max(reference_chunk_indices) + 1)
-        # TODO: split proportionally.
-        if isinstance(chunker, DefaultChunker):
-            chunker = CountBasedChunker(2 * DefaultChunker.DEFAULT_CHUNK_COUNT)
-
-    value_counts = calculate_value_counts(
-        data=data,
-        chunker=chunker,
-        timestamps=timestamps,
-        max_number_of_categories=5,
-        missing_category_label='Missing',
-    )
-    categories = value_counts[column_name].cat.categories
+        data_to_categorize = pd.concat([reference_data, analysis_data])
+    categories = categorize_data(data_to_categorize, max_number_of_categories=5)
 
     if has_reference_results:
-        reference_value_counts = value_counts.loc[value_counts["chunk_indices"].isin(reference_chunk_indices)]
+        reference_value_counts = calculate_value_counts(
+            data=reference_data,
+            categories=categories,
+            chunker=chunker,
+            timestamps=reference_data_timestamps,
+            missing_category_label='Missing',
+        )
 
         figure = stacked_bar(
             figure=figure,
@@ -311,7 +302,13 @@ def _plot_stacked_bar(
             subplot_args=subplot_args,
         )
 
-    analysis_value_counts = value_counts.loc[value_counts["chunk_indices"].isin(analysis_chunk_indices)]
+    analysis_value_counts = calculate_value_counts(
+        data=analysis_data,
+        categories=categories,
+        chunker=chunker,
+        timestamps=analysis_data_timestamps,
+        missing_category_label='Missing',
+    )
 
     figure = stacked_bar(
         figure=figure,

--- a/nannyml/plots/components/stacked_bar_plot.py
+++ b/nannyml/plots/components/stacked_bar_plot.py
@@ -20,9 +20,10 @@ def calculate_value_counts(
     data: Union[np.ndarray, pd.Series],
     chunker: Chunker,
     missing_category_label,
-    max_number_of_categories,
+    max_number_of_categories: Optional[int] = None,
     timestamps: Optional[Union[np.ndarray, pd.Series]] = None,
     column_name: Optional[str] = None,
+    categories: Optional[list] = None,
 ):
     if isinstance(data, np.ndarray):
         if column_name is None:
@@ -31,21 +32,10 @@ def calculate_value_counts(
     else:
         column_name = data.name
 
-    data = data.astype("category")
-    cat_str = [str(value) for value in data.cat.categories.values]
-    data = data.cat.rename_categories(cat_str)
-    data = data.cat.add_categories([missing_category_label, 'Other'])
-    data = data.fillna(missing_category_label)
+    if categories is None:
+        categories = categorize_data(data, max_number_of_categories)
 
-    if max_number_of_categories:
-        top_categories = data.value_counts().index.tolist()[:max_number_of_categories]
-        if data.nunique() > max_number_of_categories + 1:
-            data.loc[~data.isin(top_categories)] = 'Other'
-
-    data = data.cat.remove_unused_categories()
-
-    categories_ordered = data.value_counts().index.tolist()
-    categorical_data = pd.Categorical(data, categories_ordered)
+    categorical_data = _apply_categorization(data, categories, missing_category_label)
 
     # TODO: deal with None timestamps
     if isinstance(timestamps, pd.Series):
@@ -75,6 +65,31 @@ def calculate_value_counts(
     )
 
     return value_counts_table
+
+
+def categorize_data(data: Union[np.ndarray, pd.Series], max_number_of_categories: int):
+    data = pd.Series(data).astype("category")
+    categories_ordered = data.value_counts().index.tolist()
+    if max_number_of_categories:
+        categories_ordered = categories_ordered[:max_number_of_categories]
+    return categories_ordered
+
+
+def _apply_categorization(
+    data: pd.Series,
+    categories: list,
+    missing_category_label: str
+):
+    data = data.astype("category")
+    old_categories = [str(category) for category in data.cat.categories.values]
+    new_categories = [str(category) for category in categories]
+    renaming_dict = {c: (c if c in new_categories else "Other") for c in old_categories}
+    data = data.cat.rename_categories(renaming_dict)
+    data = data.cat.add_categories([missing_category_label, "Other"])
+    data = data.fillna(missing_category_label)
+    data = data.cat.remove_unused_categories()
+    categories_ordered = data.value_counts().index.tolist()
+    return pd.Categorical(data, categories_ordered)
 
 
 def stacked_bar(

--- a/nannyml/plots/components/stacked_bar_plot.py
+++ b/nannyml/plots/components/stacked_bar_plot.py
@@ -81,6 +81,7 @@ def stacked_bar(
     figure: Figure,
     stacked_bar_table: pd.DataFrame,
     color: str,
+    categories: Optional[list[Any]] = None,
     chunk_start_dates: Optional[Union[np.ndarray, pd.Series]] = None,
     chunk_end_dates: Optional[Union[np.ndarray, pd.Series]] = None,
     chunk_indices: Optional[Union[np.ndarray, pd.Series]] = None,
@@ -95,7 +96,8 @@ def stacked_bar(
     column_name = [
         col for col in stacked_bar_table.columns if col not in ('chunk_key', 'chunk_indices', 'value_counts')
     ][0]
-    categories = stacked_bar_table[column_name].cat.categories
+    if categories is None:
+        categories = stacked_bar_table[column_name].cat.categories
     category_colors = list(
         sns.blend_palette(
             [Colors.INDIGO_PERSIAN, Colors.GRAY, Colors.BLUE_SKY_CRAYOLA], n_colors=len(categories)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ packages = [
 [tool.poetry.scripts]
 nml = "nannyml.cli.cli:cli"
 nannyml = "nannyml.cli.cli:cli"
+categorical-plot-example = "nannyml.categorical_plot_example:main"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ homepage = "https://github.com/nannyml/nannyml"
 description = "NannyML, Your library for monitoring model performance."
 authors = ["Niels Nuyttens <niels@nannyml.com>"]
 readme = "README.md"
-license = "Apache-2.0"
-classifiers = [
+license =  "Apache-2.0"
+classifiers=[
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
@@ -20,7 +20,7 @@ classifiers = [
 ]
 packages = [
     { include = "nannyml" },
-    #    { include = "tests", format = "sdist" },
+#    { include = "tests", format = "sdist" },
 ]
 
 [tool.poetry.scripts]
@@ -57,11 +57,11 @@ PyYAML = "^6.0"
 Jinja2 = "<3.1"
 pyfiglet = "^0.8.post1"
 lightgbm = ">=3.3,<4.6"
-FLAML = { extras = ["automl"], version = "^2.3.3" }
+FLAML = {extras = ["automl"], version = "^2.3.3"}
 s3fs = ">=2022.8"
-sqlmodel = { version = "^0.0", optional = true }
+sqlmodel = {version = "^0.0", optional = true}
 APScheduler = "^3.9"
-psycopg2-binary = { version = "^2.9", optional = true }
+psycopg2-binary = {version = "^2.9", optional = true}
 segment-analytics-python = "^2.3"
 python-dotenv = ">=1.0,<2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ homepage = "https://github.com/nannyml/nannyml"
 description = "NannyML, Your library for monitoring model performance."
 authors = ["Niels Nuyttens <niels@nannyml.com>"]
 readme = "README.md"
-license =  "Apache-2.0"
-classifiers=[
+license = "Apache-2.0"
+classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
@@ -20,7 +20,7 @@ classifiers=[
 ]
 packages = [
     { include = "nannyml" },
-#    { include = "tests", format = "sdist" },
+    #    { include = "tests", format = "sdist" },
 ]
 
 [tool.poetry.scripts]
@@ -57,11 +57,11 @@ PyYAML = "^6.0"
 Jinja2 = "<3.1"
 pyfiglet = "^0.8.post1"
 lightgbm = ">=3.3,<4.6"
-FLAML = {extras = ["automl"], version = "^2.3.3"}
+FLAML = { extras = ["automl"], version = "^2.3.3" }
 s3fs = ">=2022.8"
-sqlmodel = {version = "^0.0", optional = true}
+sqlmodel = { version = "^0.0", optional = true }
 APScheduler = "^3.9"
-psycopg2-binary = {version = "^2.9", optional = true}
+psycopg2-binary = { version = "^2.9", optional = true }
 segment-analytics-python = "^2.3"
 python-dotenv = ">=1.0,<2.0"
 


### PR DESCRIPTION
👋🏻 Hi!

This PR addresses two issues that I found make the plots for categorical distributions hard to work with:

1. Reference and analysis period categories are sometimes inconsistent.
2. Legends for all subplots are located near the top.

### 1. Reference and analysis period categories are sometimes inconsistent

Currently, the reference and analysis data are each categorized independently via separate calls to `calculate_value_counts`. This can lead to inconsistent categorizations because different classes may have different count rankings across both periods. E.g. the most frequent class in the reference period may not be the most frequent class in the analysis period, meaning the bottom of each stack (purple by default) will be used for different classes in different periods.

I fixed this by concating the two dataframes, making a single call to `calculate_value_counts`, then splitting the dataframe back up. There are other ways to accomplish this and I'm open to suggestions!

### 2. Legends for all subplots are located near the top.

This appears to be a long-standing issue with plotly. I applied a workaround found here:

https://community.plotly.com/t/plotly-subplots-with-individual-legends/1754/25

Note: I had to adapt it to work with more than one column of subplots.

### Results

Run the following in console to reproduce these results:

```
poetry run categorical-plot-example
```

Before:

<img width="1255" alt="before" src="https://github.com/user-attachments/assets/b1883190-74df-4607-b674-94300a0ce93b" />

After:

<img width="1323" alt="after" src="https://github.com/user-attachments/assets/414fa7f3-cae6-484b-9f9c-080c3e4091c7" />

Notice how:

* the bottom purple chunk in the hover changes category from `30%` (incorrect) to `20%` (correct)
* the legend is now co-located with the subplot

### Discussion

* The `categorical-plot-example` poetry script example is just to highlight the problem. I pulled it straight from here: https://nannyml.readthedocs.io/en/stable/tutorials/detecting_data_drift/univariate_drift_detection.html#just-the-code. It should be removed before merging.
* I'm happy to break apart the 2 separate issues into separate PRs if preferred.
* How should I test this? (If at all.)
* The `TODO` in `nannyml/plots/blueprints/distributions.py` highlights the weakness of my approach: the `chunker` now needs to be expanded to handle both datasets simultaneously. Again, open to thoughts here.
* There appears to be a parallel path to building this kind of plot via `nannyml/distribution/categorical/result.py`. Will this approach need to be mirrored in that file?